### PR TITLE
Update ros api root constant

### DIFF
--- a/src/Routes/RosPage/RosPage.js
+++ b/src/Routes/RosPage/RosPage.js
@@ -4,7 +4,7 @@ import { Card, CardBody } from '@patternfly/react-core';
 import { Main, PageHeader, PageHeaderTitle } from '@redhat-cloud-services/frontend-components';
 import './ros-page.scss';
 import { } from '@patternfly/react-core';
-import { INVENTRY_API_ROOT } from '../../constants';
+import { ROS_API_ROOT } from '../../constants';
 import asyncComponent from '../../Utilities/asyncComponent';
 const RosTable = asyncComponent(() => import('../../Components/RosTable/RosTable'));
 
@@ -30,7 +30,7 @@ class RosPage extends React.Component {
     }
 
     getSystemsForRos() {
-        fetch(INVENTRY_API_ROOT.concat('/systems'))
+        fetch(ROS_API_ROOT.concat('/systems'))
         .then((res) => {
             if (!res.ok) {
                 throw Error(res.statusText);

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,1 +1,1 @@
-export const INVENTRY_API_ROOT = 'http://localhost:5000/api';
+export const ROS_API_ROOT = '/api';


### PR DESCRIPTION
Earlier we were fetching host records from inventory but, now we have our ros api, so it would be apt to rename the constant here. Also, since we test on `https://ci.foo.redhat.com:1337/insights/ros` so, the api url shouldn't be localhost but just `/api` as it will be then mapped to the same url via `insights-proxy`.