### PR TITLE
Update root api url

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,1 +1,1 @@
-export const ROS_API_ROOT = '/api/ros';
+export const ROS_API_ROOT = '/api/ros/v0';


### PR DESCRIPTION
This change is dependent on ros-backend [PR#10](https://github.com/RedHatInsights/ros-backend/pull/10/). Once v0 api is in place in the backend, this change should get in then.