### PR TITLE
fix recommendations title as per mockup

### DIFF
--- a/src/Components/SystemDetail/SystemRecommendations.js
+++ b/src/Components/SystemDetail/SystemRecommendations.js
@@ -6,7 +6,6 @@ import { TableToolbar } from '@redhat-cloud-services/frontend-components/TableTo
 import { loadSysRecs } from '../../store/actions';
 import {
     Card,
-    CardHeader,
     CardBody,
     Title,
     Stack,
@@ -14,6 +13,7 @@ import {
     Pagination
 } from '@patternfly/react-core';
 import debounce from 'lodash/debounce';
+import './SystemRecommendations.scss';
 import asyncComponent from '../../Utilities/asyncComponent';
 const RecommendationsTable = asyncComponent(() => import('./RecommendationsTable'));
 
@@ -117,8 +117,12 @@ class SystemRecommendations extends React.Component {
             <Suspense fallback="">
                 <Stack>
                     <StackItem>
+                        <Title className="recsTitle" headingLevel="h3" size="2xl">
+                            Recommendations
+                        </Title>
+                    </StackItem>
+                    <StackItem>
                         <Card>
-                            <CardHeader><Title headingLevel="h1">Recommendations</Title></CardHeader>
                             <CardBody>
                                 <PrimaryToolbar className="ros-primary-toolbar" pagination={{
                                     page: (totalRecs === 0 ? 0 : page),

--- a/src/Components/SystemDetail/SystemRecommendations.js
+++ b/src/Components/SystemDetail/SystemRecommendations.js
@@ -13,7 +13,6 @@ import {
     Pagination
 } from '@patternfly/react-core';
 import debounce from 'lodash/debounce';
-import './SystemRecommendations.scss';
 import asyncComponent from '../../Utilities/asyncComponent';
 const RecommendationsTable = asyncComponent(() => import('./RecommendationsTable'));
 
@@ -115,9 +114,9 @@ class SystemRecommendations extends React.Component {
         const { page, perPage } = this.state;
         return (
             <Suspense fallback="">
-                <Stack>
+                <Stack hasGutter>
                     <StackItem>
-                        <Title className="recsTitle" headingLevel="h3" size="2xl">
+                        <Title headingLevel="h3" size="2xl">
                             Recommendations
                         </Title>
                     </StackItem>

--- a/src/Components/SystemDetail/SystemRecommendations.scss
+++ b/src/Components/SystemDetail/SystemRecommendations.scss
@@ -1,3 +1,0 @@
-.recsTitle {
-  margin-bottom: var(--pf-global--spacer--lg);
-}

--- a/src/Components/SystemDetail/SystemRecommendations.scss
+++ b/src/Components/SystemDetail/SystemRecommendations.scss
@@ -1,0 +1,3 @@
+.recsTitle {
+  margin-bottom: var(--pf-global--spacer--lg);
+}


### PR DESCRIPTION
With reference to mockup page - https://marvelapp.com/prototype/9408d9j/screen/77819763

Before: Title 'Recommendations' was shown on the card
![Screenshot from 2021-04-29 14-57-59](https://user-images.githubusercontent.com/6470528/116531208-8a45fe80-a8fc-11eb-9cf2-48ca154359ea.png)

After:
![Screenshot from 2021-04-29 14-36-20](https://user-images.githubusercontent.com/6470528/116530914-33d8c000-a8fc-11eb-85b4-20a7d1cac569.png)

+ adding @karelhala & @terezanovotna into loop for review
