### PR TITLE
Disable default columns to keep it backwards compatible

### DIFF
--- a/src/Routes/RosPage/RosPage.js
+++ b/src/Routes/RosPage/RosPage.js
@@ -126,6 +126,7 @@ class RosPage extends React.Component {
                     <Card className='pf-t-light  pf-m-opaque-100'>
                         <CardBody>
                             <InventoryTable
+                                disableDefaultColumns
                                 ref={this.inventory}
                                 hasCheckbox={ false }
                                 tableProps={{


### PR DESCRIPTION
This will ensure that a newer version of insights inventory table would not break columns.

cc @karelhala 