### PR TITLE
RHIROS-222 - disable redirection links for deleted/culled systems

### DIFF
--- a/src/Routes/RosPage/RosPage.js
+++ b/src/Routes/RosPage/RosPage.js
@@ -162,10 +162,14 @@ class RosPage extends React.Component {
                                                     hasItems: true
                                                 });
                                                 return {
-                                                    results: results.data.map((system) => ({
-                                                        ...invSystems.find(({ id }) => id === system.inventory_id),
-                                                        ...system
-                                                    })),
+                                                    results: results.data.map((system) => {
+                                                        const invRec = invSystems.find(({ id }) => id === system.inventory_id);
+                                                        return ({
+                                                            ...invRec,
+                                                            ...(invRec ? { isDeleted: false } : { id: system.inventory_id, isDeleted: true }),
+                                                            ...system
+                                                        });
+                                                    }),
                                                     total: results.meta.count,
                                                     page: config.page,
                                                     per_page: config.per_page /* eslint-disable-line camelcase */

--- a/src/store/entitiesReducer.js
+++ b/src/store/entitiesReducer.js
@@ -1,14 +1,21 @@
 import { applyReducerHash } from '@redhat-cloud-services/frontend-components-utilities/ReducerRegistry';
 import { Link } from 'react-router-dom';
 import React from 'react';
+import { Tooltip } from '@patternfly/react-core';
 import { ExpandedRow } from '../Components/RosTable/ExpandedRow';
 import { ProgressScoreBar } from '../Components/RosTable/ProgressScoreBar';
 
-export const systemName = (displayName, id, { inventory_id: inventoryId }) => {
+export const systemName = (displayName, id, { inventory_id: inventoryId, isDeleted }) => {
     return (
-        <Link to={{ pathname: `/${inventoryId}` }} className={ `pf-link system-link link-${inventoryId}` }>
-            { displayName }
-        </Link>
+        isDeleted ? (
+            <Tooltip content={<div>{displayName} has been deleted from inventory</div>}>
+                <span tabIndex="0">{ displayName }</span>
+            </Tooltip>
+        ) : (
+            <Link to={{ pathname: `/${inventoryId}` }} className={ `pf-link system-link link-${inventoryId}` }>
+                { displayName }
+            </Link>
+        )
     );
 };
 
@@ -18,12 +25,14 @@ export const scoreProgress = (data) => {
     );
 };
 
-export const recommendations = (data, id, { inventory_id: inventoryId }) => {
+export const recommendations = (data, id, { inventory_id: inventoryId, isDeleted }) => {
     return (
-        <Link to={{ pathname: `/${inventoryId}` }}
-            className={ `pf-link recommendations ${data === 0 ? 'green-400' : ''} link-${inventoryId}` }>
-            { data }
-        </Link>
+        isDeleted ? <span className='recommendations'>{ data }</span> : (
+            <Link to={{ pathname: `/${inventoryId}` }}
+                className={ `pf-link recommendations ${data === 0 ? 'green-400' : ''} link-${inventoryId}` }>
+                { data }
+            </Link>
+        )
     );
 };
 


### PR DESCRIPTION
With commit changes, disabling redirection links on ROS system list to avoid below scenario where two empty states are shown on system detail page, 
![Screenshot from 2021-07-24 00-16-51](https://user-images.githubusercontent.com/6470528/127828322-cdd71d43-c3b3-48e5-8ce0-7cab6a2e6a0c.png)

This is a very rare scenario when user tries to access ROS systems page when any system(s) either deleted from inventory but deletion of respective records from ROS is yet to happen OR marked as culled but a job which triggers deletion from DB not yet executed.

After disabling redirection links, systems list look like below screenshot. Added tooltip to indicate that a particular system is deleted from inventory.
![Screenshot from 2021-07-29 22-28-46](https://user-images.githubusercontent.com/6470528/127826280-4688ffe1-84c8-43e5-9df5-7d86a4a194bf.png)

+ adding @karelhala, @terezanovotna and @kuklas into loop for review

