### PR TITLE
RHIROS-262 - rename score(1-5) to utilization(%)

### DIFF
--- a/src/Components/RosTable/ProgressScoreBar.js
+++ b/src/Components/RosTable/ProgressScoreBar.js
@@ -2,8 +2,7 @@ import React from 'react';
 import { Progress } from '@patternfly/react-core';
 import propTypes from 'prop-types';
 
-export const ProgressScoreBar = ({ valueScore, measureLocation, eleId }) =>  {
-    const textLabel = `${ valueScore }/5`;
+export const ProgressScoreBar = ({ valueScore, utilizedValue, measureLocation, eleId }) =>  {
     const colorclass = (val) =>  ({
         5: 'green-400',
         4: 'green-100',
@@ -13,8 +12,7 @@ export const ProgressScoreBar = ({ valueScore, measureLocation, eleId }) =>  {
 
     return (
         <React.Fragment>
-            <Progress value={ valueScore } min={0} max={5} label={ textLabel }
-                valueText={ textLabel }
+            <Progress value={ utilizedValue }
                 className={ `progress-score-bar ${colorclass(valueScore)}` }
                 measureLocation={ measureLocation }
                 {  ...(eleId ? { id: eleId } : null) } />
@@ -25,5 +23,6 @@ export const ProgressScoreBar = ({ valueScore, measureLocation, eleId }) =>  {
 ProgressScoreBar.propTypes = {
     measureLocation: propTypes.string,
     valueScore: propTypes.number,
+    utilizedValue: propTypes.number,
     eleId: propTypes.string
 };

--- a/src/Components/RosTable/ProgressScoreBar.test.js
+++ b/src/Components/RosTable/ProgressScoreBar.test.js
@@ -10,17 +10,25 @@ describe('ProgressScoreBar component', () => {
 
     it('expect to render bar with danger-200', () => {
         const component = renderer.create(
-            <ProgressScoreBar measureLocation='outside' valueScore={1} eleId='123' />
+            <ProgressScoreBar
+                measureLocation='outside'
+                valueScore={1}
+                eleId='123'
+                utilizedValue={20} />
         );
         expect(component.toJSON()).toMatchSnapshot();
         const progressInstance = component.root.findByType(Progress);
         expect(progressInstance.props.className.includes('danger-200')).toBe(true);
-        expect(progressInstance.props.value).toBe(1);
+        expect(progressInstance.props.value).toBe(20);
     });
 
     it('expect to render with orange-300 class', () => {
         const { container } = render(
-            <ProgressScoreBar measureLocation='outside' valueScore={2} eleId='345'/>
+            <ProgressScoreBar
+                measureLocation='outside'
+                valueScore={2}
+                eleId='345'
+                utilizedValue={40} />
         );
         expect(container.getElementsByClassName('pf-c-progress').length).toBe(1);
         expect(container.firstChild).toHaveClass('orange-300');

--- a/src/Components/RosTable/__snapshots__/ProgressScoreBar.test.js.snap
+++ b/src/Components/RosTable/__snapshots__/ProgressScoreBar.test.js.snap
@@ -20,14 +20,13 @@ exports[`ProgressScoreBar component expect to render bar with danger-200 1`] = `
     <span
       className="pf-c-progress__measure"
     >
-      1/5
+      20%
     </span>
   </div>
   <div
-    aria-valuemax={5}
+    aria-valuemax={100}
     aria-valuemin={0}
-    aria-valuenow={1}
-    aria-valuetext="1/5"
+    aria-valuenow={20}
     className="pf-c-progress__bar"
     role="progressbar"
   >

--- a/src/Routes/RosPage/RosPage.js
+++ b/src/Routes/RosPage/RosPage.js
@@ -34,9 +34,9 @@ class RosPage extends React.Component {
             orderDirection: SortByDirection.asc,
             columns: [
                 { key: 'display_name', title: 'Name', renderFunc: systemName },
-                { key: 'display_performance_score.cpu_score', title: 'CPU score', renderFunc: scoreProgress },
-                { key: 'display_performance_score.memory_score', title: 'Memory score', renderFunc: scoreProgress },
-                { key: 'display_performance_score.io_score', title: 'I/O score', renderFunc: scoreProgress },
+                { key: 'performance_utilization.cpu', title: 'CPU utilization', renderFunc: scoreProgress('cpu') },
+                { key: 'performance_utilization.memory', title: 'Memory utilization', renderFunc: scoreProgress('memory') },
+                { key: 'performance_utilization.io', title: 'I/O utilization', renderFunc: scoreProgress('io') },
                 { key: 'number_of_recommendations', title: 'Recommendations',
                     renderFunc: recommendations },
                 { key: 'state', title: 'State', renderFunc: displayState }
@@ -45,9 +45,9 @@ class RosPage extends React.Component {
 
         this.sortingHeader = {
             display_name: 'display_name', /* eslint-disable-line camelcase */
-            'display_performance_score.cpu_score': 'cpu_score',
-            'display_performance_score.memory_score': 'memory_score',
-            'display_performance_score.io_score': 'io_score',
+            'performance_utilization.cpu': 'cpu',
+            'performance_utilization.memory': 'memory',
+            'performance_utilization.io': 'io',
             number_of_recommendations: 'number_of_recommendations', /* eslint-disable-line camelcase */
             state: 'state' };
 

--- a/src/store/entitiesReducer.js
+++ b/src/store/entitiesReducer.js
@@ -24,9 +24,10 @@ export const displayState = (data) => {
     return (<SystemState stateValue={ data }/>);
 };
 
-export const scoreProgress = (data) => {
+export const scoreProgress = (propName) => (data, _id, { display_performance_score: scoreObject }) => {
     return (
-        <ProgressScoreBar measureLocation='outside' valueScore={data} />
+        <ProgressScoreBar measureLocation='outside'
+            valueScore={scoreObject[propName]} utilizedValue={data} />
     );
 };
 


### PR DESCRIPTION
With this commit, it shows "{cpu/memory/IO} score" to  "{cpu/memory/IO} utilization" and percentage(%) values instead of 1-5 score.

Screenshot for reference - 
![Screenshot from 2021-09-16 21-19-36](https://user-images.githubusercontent.com/6470528/133644700-3f240c83-2194-4e52-bc09-d90f10b78552.png)

+adding @karelhala, @terezanovotna and @kuklas into loop for review

Required backend [PR-106](https://github.com/RedHatInsights/ros-backend/pull/106) change