### PR TITLE
RHIROS-388 - fixed store already initialized error

### DIFF
--- a/src/AppEntry.js
+++ b/src/AppEntry.js
@@ -7,9 +7,7 @@ import { getBaseName } from '@redhat-cloud-services/frontend-components-utilitie
 import logger from 'redux-logger';
 
 const RosApp = () => (
-    <Provider store={ init(
-        ...(process.env.NODE_ENV !== 'production' ? [logger] : [])
-    ).getStore() }>
+    <Provider store={ init(process.env.NODE_ENV !== 'production' && logger).getStore() }>
         <Router basename={ getBaseName(window.location.pathname, 2) }>
             <App />
         </Router>

--- a/src/AppEntry.js
+++ b/src/AppEntry.js
@@ -4,9 +4,12 @@ import { Provider } from 'react-redux';
 import { init } from './store';
 import App from './App';
 import { getBaseName } from '@redhat-cloud-services/frontend-components-utilities/helpers';
+import logger from 'redux-logger';
 
 const RosApp = () => (
-    <Provider store={ init().getStore() }>
+    <Provider store={ init(
+        ...(process.env.NODE_ENV !== 'production' ? [logger] : [])
+    ).getStore() }>
         <Router basename={ getBaseName(window.location.pathname, 2) }>
             <App />
         </Router>

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,25 +1,14 @@
-import ReducerRegistry from '@redhat-cloud-services/frontend-components-utilities/ReducerRegistry';
+import { getRegistry } from '@redhat-cloud-services/frontend-components-utilities/Registry';
 import promiseMiddleware from 'redux-promise-middleware';
 let registry;
 
 export function init (...middleware) {
-    if (registry) {
-        throw new Error('store already initialized');
-    }
-
-    registry = new ReducerRegistry({}, [
+    registry = getRegistry({}, [
         promiseMiddleware,
         ...middleware
     ]);
 
-    // registry.register({ rosSystemsTableState: rosSystemsTableRootReducer });
 
-    //If you want to register all of your reducers, this is good place.
-    /*
-     *  registry.register({
-     *    someName: (state, action) => ({...state})
-     *  });
-     */
     return registry;
 }
 

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -8,7 +8,6 @@ export function init (...middleware) {
         ...middleware
     ]);
 
-
     return registry;
 }
 


### PR DESCRIPTION
Background:

We were facing 'store already initliazed' error on ROS service page while switching between ROS service and other services. This PR fixes the issue.

Jira Card: https://issues.redhat.com/browse/RHIROS-388