### PR TITLE
fixed store creation condition causing issue in prod env

### DIFF
--- a/src/AppEntry.js
+++ b/src/AppEntry.js
@@ -7,7 +7,7 @@ import { getBaseName } from '@redhat-cloud-services/frontend-components-utilitie
 import logger from 'redux-logger';
 
 const RosApp = () => (
-    <Provider store={ init(process.env.NODE_ENV !== 'production' && logger).getStore() }>
+    <Provider store={ process.env.NODE_ENV !== 'production' ? init(logger).getStore() : init().getStore() }>
         <Router basename={ getBaseName(window.location.pathname, 2) }>
             <App />
         </Router>


### PR DESCRIPTION
**Background:**
There was an issue in the prod env while creating the store as due to the below condition in the init method 'false' was getting passed in the production environment hence resulting in error `middleware is not a function` while store creation.

```
init(process.env.NODE_ENV !== 'production' && logger)
``` 

**Discussion link:** https://ansible.slack.com/archives/C023VGW21NU/p1637749400317400

In this PR I have updated the code to fix the above issue.

**Steps to test:**
* update the `NODE_ENV` value between `development` and production` in the `start` script of the `package.json` file and observe the behaviour. It should work fine in both scenarios.

