### PR TITLE
RHIROS-379 show rules content with newline and tab space

### DIFF
--- a/src/Components/SystemDetail/RecommendationsTable.js
+++ b/src/Components/SystemDetail/RecommendationsTable.js
@@ -11,11 +11,11 @@ import './RecommendationsTable.scss';
 const renderExpandedView = (row) => {
     return (
         <TextContent>
-            <Text component={TextVariants.p}>
+            <Text component={TextVariants.p} className="newline tab">
                 <Text><strong>Detected issues</strong></Text>
                 {row.reason}
             </Text>
-            <Text component={TextVariants.p}>
+            <Text component={TextVariants.p} className="newline">
                 <Text><strong>Suggestion</strong></Text>
                 {row.resolution}
             </Text>

--- a/src/Components/SystemDetail/RecommendationsTable.scss
+++ b/src/Components/SystemDetail/RecommendationsTable.scss
@@ -2,7 +2,12 @@
   tr {
     --pf-c-table--cell--FontSize: var(--pf-global--FontSize--md);
   }
-
+  .newline {
+    white-space: pre-line;
+  }
+  .tab {
+    white-space: pre-wrap;
+  }
   .recs-table-empty {
     .pf-c-empty-state__icon {
       fill: var(--pf-global--success-color--100);

--- a/src/Components/SystemDetail/__snapshots__/RecommendationsTable.test.js.snap
+++ b/src/Components/SystemDetail/__snapshots__/RecommendationsTable.test.js.snap
@@ -134,7 +134,7 @@ exports[`RecommendationsTable component matches snapshot 1`] = `
             className="pf-c-content"
           >
             <p
-              className=""
+              className="newline tab"
               data-pf-content={true}
             >
               <p
@@ -148,7 +148,7 @@ exports[`RecommendationsTable component matches snapshot 1`] = `
               This may be caused due to inappropriate consumption model.
             </p>
             <p
-              className=""
+              className="newline"
               data-pf-content={true}
             >
               <p


### PR DESCRIPTION
These changes are required to test the new rules content in the UI. Test with [RHIROS-424](https://issues.redhat.com/browse/RHIROS-424) (for backend changes) and [RHIROS-404](https://issues.redhat.com/browse/RHIROS-404) (new rules content in the seed file).

![Screenshot from 2021-12-13 17-33-23](https://user-images.githubusercontent.com/61837065/145955031-818458f0-4447-47f1-acfb-6c1c7d61afd6.png)

