### PR TITLE
RHIROS-426 changed the value for ROS_API_ROOT to '/api/ros/v1'

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,5 +1,5 @@
 // API
-export const ROS_API_ROOT = '/api/ros/v0';
+export const ROS_API_ROOT = '/api/ros/v1';
 export const IS_CONFIGURED_API = '/is_configured';
 export const SYSTEMS_API_ROOT = '/systems';
 export const RECOMMENDATION_RATING_API = '/rating';


### PR DESCRIPTION
This PR is needed for upgrading api routes from v0 to v1 on frontend side also. We have already fixed on the backend side [https://issues.redhat.com/browse/RHIROS-426](https://issues.redhat.com/browse/RHIROS-426)