### PR TITLE
RHIROS-421 updated under-pressure state icon color

### DIFF
--- a/src/Components/RosTable/SystemState.js
+++ b/src/Components/RosTable/SystemState.js
@@ -39,7 +39,7 @@ const stateDetails = (val) =>  ({
     },
     'Under pressure': {
         text: 'System resources adequate but experiencing occasional peaks.',
-        icon: <TachometerAltIcon color='#2B9AF3' size='sm'/>
+        icon: <TachometerAltIcon color='#030303' size='sm'/>
     }
 }[val] || {});
 


### PR DESCRIPTION
Updated icon color for Under pressure state as per https://issues.redhat.com/browse/RHIROS-421

Screenshot:

![image](https://user-images.githubusercontent.com/5928530/146730885-00aad6c2-cec4-4aad-b49e-2f207422a56a.png)
