### PR TITLE
[RHIROS-442] Update ROS not configured page

### DIFF
--- a/src/Components/ServiceNotConfigured/ServiceNotConfigured.js
+++ b/src/Components/ServiceNotConfigured/ServiceNotConfigured.js
@@ -14,37 +14,8 @@ export const ServiceNotConfigured = () => (
             <Title headingLevel="h5" size="lg">
               Resource optimization isn&apos;t configured yet
             </Title>
-            <EmptyStateBody>
-                <Bullseye>
-                    <Stack hasGutter>
-                        <StackItem>To start configuration, follow these steps.</StackItem>
-                        <StackItem>
-                            1. Prerequisites: insights-client, ansible (Read FAQ if you
-                don&apos;t know how to install it).
-                        </StackItem>
-                        <StackItem>
-                            2. Download and run playbook.
-                        </StackItem>
-                        <StackItem>
-                            <ClipboardCopy>
-                                curl -O https://raw.githubusercontent.com/RedHatInsights/ros-backend/main/ansible-playbooks/ros_install_and_set_up.yml
-                            </ClipboardCopy>
-                        </StackItem>
-                        <StackItem>
-                            Append localhost to /etc/ansible/hosts
-                        </StackItem>
-                        <StackItem>
-                            <ClipboardCopy>ansible-playbook -c local ros_install_and_set_up.yml</ClipboardCopy>
-                        </StackItem>
-                        <StackItem>
-                            3. Wait <strong>24 hours</strong> for your upload to complete.
-                            At completion, metrics from the previous day will be provided.
-                        </StackItem>
-                    </Stack>
-                </Bullseye>
-            </EmptyStateBody>
-            <Button component="a" href="https://access.redhat.com/articles/6245921" target="_blank" variant="primary">
-                Getting started documentation
+            <Button component="a" href="https://access.redhat.com/documentation/en-us/red_hat_insights/2022/html/assessing_and_monitoring_rhel_resource_optimization_with_insights_for_red_hat_enterprise_linux/proc-ros-install_ros-getting-started" target="_blank" variant="primary">
+                Check our getting started documentation to configure it.
             </Button>
         </EmptyState>
     </Bullseye>

--- a/src/Components/ServiceNotConfigured/ServiceNotConfigured.js
+++ b/src/Components/ServiceNotConfigured/ServiceNotConfigured.js
@@ -5,6 +5,7 @@ import {
 } from '@patternfly/react-core';
 import { WrenchIcon } from '@patternfly/react-icons';
 import React from 'react';
+import { GETTING_STARTED_URL } from '../../constants';
 import './ServiceNotConfigured.scss';
 
 export const ServiceNotConfigured = () => (
@@ -32,8 +33,11 @@ export const ServiceNotConfigured = () => (
                     </Stack>
                 </Bullseye>
             </EmptyStateBody>
-            { // eslint-disable-next-line max-len }
-            <Button component="a" href="https://access.redhat.com/documentation/en-us/red_hat_insights/2022/html/assessing_and_monitoring_rhel_resource_optimization_with_insights_for_red_hat_enterprise_linux/proc-ros-install_ros-getting-started" target="_blank" variant="primary">
+            <Button
+                component="a"
+                href={GETTING_STARTED_URL}
+                target="_blank"
+                variant="primary">
                 Getting started documentation.
             </Button>
         </EmptyState>

--- a/src/Components/ServiceNotConfigured/ServiceNotConfigured.js
+++ b/src/Components/ServiceNotConfigured/ServiceNotConfigured.js
@@ -1,7 +1,6 @@
 import {
-    Bullseye, EmptyState, EmptyStateBody,
-    EmptyStateIcon, Title, Stack,
-    StackItem, ClipboardCopy, Button
+    Bullseye, EmptyState,
+    EmptyStateIcon, Title, Button
 } from '@patternfly/react-core';
 import { WrenchIcon } from '@patternfly/react-icons';
 import React from 'react';

--- a/src/Components/ServiceNotConfigured/ServiceNotConfigured.js
+++ b/src/Components/ServiceNotConfigured/ServiceNotConfigured.js
@@ -1,6 +1,7 @@
 import {
-    Bullseye, EmptyState,
-    EmptyStateIcon, Title, Button
+    Bullseye, EmptyState, EmptyStateBody,
+    EmptyStateIcon, Title, Stack,
+    StackItem, Button
 } from '@patternfly/react-core';
 import { WrenchIcon } from '@patternfly/react-icons';
 import React from 'react';
@@ -13,9 +14,27 @@ export const ServiceNotConfigured = () => (
             <Title headingLevel="h5" size="lg">
               Resource optimization isn&apos;t configured yet
             </Title>
-            // eslint-disable-next-line max-len
+            <EmptyStateBody>
+                <Bullseye>
+                    <Stack hasGutter>
+                        <StackItem>
+                            Resource Optimization requires installing and configuring Performance Co-Pilot on
+                            the client system.
+                        </StackItem>
+                        <StackItem>
+                            Check the documentation to find how to configure Resource Optimization with Ansible. An
+                            alternative method which does not require Ansible is also described.
+                        </StackItem>
+                        <StackItem>
+                            After configuring Resource Optimization, it may take up to 24 hours until suggestions
+                            are available.
+                        </StackItem>
+                    </Stack>
+                </Bullseye>
+            </EmptyStateBody>
+            { // eslint-disable-next-line max-len }
             <Button component="a" href="https://access.redhat.com/documentation/en-us/red_hat_insights/2022/html/assessing_and_monitoring_rhel_resource_optimization_with_insights_for_red_hat_enterprise_linux/proc-ros-install_ros-getting-started" target="_blank" variant="primary">
-                Check our getting started documentation to configure it.
+                Getting started documentation.
             </Button>
         </EmptyState>
     </Bullseye>

--- a/src/Components/ServiceNotConfigured/ServiceNotConfigured.js
+++ b/src/Components/ServiceNotConfigured/ServiceNotConfigured.js
@@ -13,6 +13,7 @@ export const ServiceNotConfigured = () => (
             <Title headingLevel="h5" size="lg">
               Resource optimization isn&apos;t configured yet
             </Title>
+            // eslint-disable-next-line max-len
             <Button component="a" href="https://access.redhat.com/documentation/en-us/red_hat_insights/2022/html/assessing_and_monitoring_rhel_resource_optimization_with_insights_for_red_hat_enterprise_linux/proc-ros-install_ros-getting-started" target="_blank" variant="primary">
                 Check our getting started documentation to configure it.
             </Button>

--- a/src/constants.js
+++ b/src/constants.js
@@ -12,3 +12,7 @@ export const POSITIVE_FEEDBACK = 1;
 // No Data State
 export const NO_DATA_STATE = 'Waiting for data';
 export const NO_DATA_VALUE = 'N/A';
+
+// Getting started URL
+// eslint-disable-next-line max-len
+export const GETTING_STARTED_URL = 'https://access.redhat.com/documentation/en-us/red_hat_insights/2022/html/assessing_and_monitoring_rhel_resource_optimization_with_insights_for_red_hat_enterprise_linux/proc-ros-install_ros-getting-started';


### PR DESCRIPTION
Since we have documented how to enable ROS with and without Ansible, instead of showing a long page with instructions and maintaining those instructions in two places (docs and ros-frontend), let's just show link to getting started docs.

Jira:  https://issues.redhat.com/browse/RHIROS-442

Screenshot:
![image](https://user-images.githubusercontent.com/5928530/146991656-c27e112a-bcce-4e49-9ae6-e95dec26fb96.png)
