### PR TITLE
fixed typo for getting started button

### DIFF
--- a/src/Components/ServiceNotConfigured/ServiceNotConfigured.js
+++ b/src/Components/ServiceNotConfigured/ServiceNotConfigured.js
@@ -38,7 +38,7 @@ export const ServiceNotConfigured = () => (
                 href={GETTING_STARTED_URL}
                 target="_blank"
                 variant="primary">
-                Getting started documentation.
+                Getting started documentation
             </Button>
         </EmptyState>
     </Bullseye>


### PR DESCRIPTION
The `Getting started documentation` button has . in it, this PR fixes that.