### PR TITLE
Disable sass prefix, AsyncComponent wraps now component with correct namespace

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -2,7 +2,6 @@ const { resolve } = require('path');
 const config = require('@redhat-cloud-services/frontend-components-config');
 const { config: webpackConfig, plugins } = config({
     rootFolder: resolve(__dirname, '../'),
-    sassPrefix: '.ros, .inventory',
     debug: true,
     https: true,
     ...(process.env.BETA && { deployment: 'beta/apps' })

--- a/config/prod.webpack.config.js
+++ b/config/prod.webpack.config.js
@@ -1,8 +1,7 @@
 const { resolve } = require('path');
 const config = require('@redhat-cloud-services/frontend-components-config');
 const { config: webpackConfig, plugins } = config({
-    rootFolder: resolve(__dirname, '../'),
-    sassPrefix: '.ros, .inventory'
+    rootFolder: resolve(__dirname, '../')
 });
 
 plugins.push(


### PR DESCRIPTION
### No need for custom sass prefix

From the version [@redhat-cloud-services/frontend-components/v/3.3.14](https://www.npmjs.com/package/@redhat-cloud-services/frontend-components/v/3.3.14) from this PR [RedHatInsights/frontend-components/pull/1239](https://github.com/RedHatInsights/frontend-components/pull/1239) it's not required to pass custom sass prefix to apply styles from/to different application. On contrary ROS app was affecting inventory by changing the inventory table styling.