### PR TITLE
Simpler wording for the no suggestions case

### DIFF
--- a/src/Components/SystemDetail/RecommendationsTable.js
+++ b/src/Components/SystemDetail/RecommendationsTable.js
@@ -71,7 +71,7 @@ class RecommendationsTable extends React.Component {
                             title: <EmptyTable className='recs-table-empty'>
                                 <EmptyStateDisplay title="No suggestions"
                                     text={[
-                                        'This system isn\'t affected by any known suggestions.'
+                                        'There are no suggestions for this system.'
                                     ]}
                                     icon={CheckCircleIcon}/>
                             </EmptyTable>


### PR DESCRIPTION
For historical reasons (when we used to talk about "risks"), our wording when there are no suggestions is a bit convoluted. Let's simplify it.