### PR TITLE
updated dev webpack config to use webpack proxy

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -4,7 +4,12 @@ const { config: webpackConfig, plugins } = config({
     rootFolder: resolve(__dirname, '../'),
     debug: true,
     https: true,
-    ...(process.env.BETA && { deployment: 'beta/apps' })
+    appUrl: process.env.BETA ? '/beta/insights/ros' : '/insights/ros',
+    env: `${process.env.ENVIRONMENT || 'stage'}-${process.env.BETA ? 'beta' : 'stable'}`,
+    deployment: process.env.BETA ? 'beta/apps' : 'apps',
+    useProxy: true,
+    useChromeTemplate: true,
+    localChrome: process.env.INSIGHTS_CHROME
 });
 
 plugins.push(

--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -1,3 +1,5 @@
+// Reference link: https://github.com/RedHatInsights/frontend-components/tree/master/packages/config#redhat-cloud-services-frontend-components---webpack-config
+
 const { resolve } = require('path');
 const config = require('@redhat-cloud-services/frontend-components-config');
 const { config: webpackConfig, plugins } = config({
@@ -8,6 +10,7 @@ const { config: webpackConfig, plugins } = config({
     env: `${process.env.ENVIRONMENT || 'stage'}-${process.env.BETA ? 'beta' : 'stable'}`,
     deployment: process.env.BETA ? 'beta/apps' : 'apps',
     useProxy: true,
+    proxyVerbose: true,
     useChromeTemplate: true,
     localChrome: process.env.INSIGHTS_CHROME
 });

--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line max-len
 // Reference link: https://github.com/RedHatInsights/frontend-components/tree/master/packages/config#redhat-cloud-services-frontend-components---webpack-config
 
 const { resolve } = require('path');

--- a/package.json
+++ b/package.json
@@ -107,9 +107,5 @@
   },
   "insights": {
     "appname": "ros"
-  },
-  "routes": {
-    "rosPage": "/ros",
-    "rosSystemDetail": "/:inventoryId"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "server:ctr": "node src/server/generateServerKey.js",
     "start": "NODE_ENV=development webpack serve --config config/dev.webpack.config.js",
     "start:beta": "NODE_ENV=development BETA=true webpack serve --config config/dev.webpack.config.js",
+    "start:prod": "NODE_ENV=development ENVIRONMENT=prod webpack serve --config config/dev.webpack.config.js",
+    "start:prod:beta": "NODE_ENV=development BETA=true ENVIRONMENT=prod webpack serve --config config/dev.webpack.config.js",
     "test": "jest --verbose",
     "verify": "npm-run-all build lint test"
   },

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "prod": "NODE_ENV=production webpack serve --config config/dev.webpack.config.js",
     "server:ctr": "node src/server/generateServerKey.js",
     "start": "NODE_ENV=development webpack serve --config config/dev.webpack.config.js",
+    "start:beta": "NODE_ENV=development BETA=true webpack serve --config config/dev.webpack.config.js",
     "test": "jest --verbose",
     "verify": "npm-run-all build lint test"
   },

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -1,7 +1,6 @@
 import { Redirect, Route, Switch } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import React, { Suspense, lazy } from 'react';
-import { routes as paths } from '../package.json';
 import { Bullseye, Spinner } from '@patternfly/react-core';
 
 const RosPage = lazy(() => import(/* webpackChunkName: "RosPage" */ './Routes/RosPage/RosPage'));
@@ -13,9 +12,9 @@ export const Routes = () => (
     </Bullseye>}>
         <Switch>
             <Route exact path='/' component={RosPage} />
-            <Route path={paths.rosSystemDetail} component={RosSystemDetail} />
+            <Route path='/:inventoryId' component={RosSystemDetail} />
             <Route>
-                <Redirect to={paths.rosPage} />
+                <Redirect to='/ros' />
             </Route>
         </Switch>
     </Suspense>


### PR DESCRIPTION
### Description

Updated dev.webpack.config.js to use webpack proxy as [insights-proxy](https://github.com/RedHatInsights/insights-proxy) project is deprecated.

Also updated the config to run it in stage env by default and added scripts for  beta and prod environments.

Jira: https://issues.redhat.com/browse/RHIROS-229