### PR TITLE
RHIROS-508 fixed RBAC permission cache issue

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -55,7 +55,7 @@ class App extends Component {
             }
         });
         (async () => {
-            const rosPermissions = await insights.chrome.getUserPermissions('ros');
+            const rosPermissions = await insights.chrome.getUserPermissions('ros', true);
             this.handlePermissionsUpdate(
                 rosPermissions.some(({ permission }) => this.hasPermission(permission, ['ros:*:*', 'ros:*:read']))
             );


### PR DESCRIPTION
### Description

RBAC permissions are getting cached at the moment which means until we won't reload ROS page it will not get updated.

Jira: https://issues.redhat.com/browse/RHIROS-508

### Reference
Slack thread: https://ansible.slack.com/archives/C02T90PLJ5V/p1643300401179300
Docs: https://github.com/RedHatInsights/frontend-components/blob/master/packages/docs/pages/chrome/chrome-api.md#getuserpermissions

### Video
https://drive.google.com/file/d/1cnXqI6o9HKO3XkcJlSAJkY9wnUNtox66/view?usp=sharing




