### PR TITLE
Ref-RHIROS-518 fixed OS column name in modal

### DIFF
--- a/src/Components/Modals/ManageColumnsModal.js
+++ b/src/Components/Modals/ManageColumnsModal.js
@@ -97,7 +97,7 @@ export const ManageColumnsModal = ({ modalColumns, isModalOpen, setModalOpen, sa
                                     dataListCells={[
                                         <DataListCell key={`column-table-item-${index}`}>
                                             <label>
-                                                {column.title}
+                                                {column.modalTitle}
                                             </label>
                                         </DataListCell>
                                     ]}

--- a/src/constants.js
+++ b/src/constants.js
@@ -68,6 +68,7 @@ export const SYSTEM_TABLE_COLUMNS = [
     {
         key: 'display_name',
         title: 'Name',
+        modalTitle: 'Name',
         renderFunc: (data, id, item) => systemName(data, id, item),
         isChecked: true,
         isDisabled: true,
@@ -80,6 +81,7 @@ export const SYSTEM_TABLE_COLUMNS = [
                 <span>OS</span>
             </Tooltip>
         ),
+        modalTitle: 'Operating system',
         dataLabel: 'Operating system',
         renderFunc: (data) => displayOS(data),
         props: { isStatic: true },
@@ -90,6 +92,7 @@ export const SYSTEM_TABLE_COLUMNS = [
     {
         key: 'performance_utilization.cpu',
         title: 'CPU utilization',
+        modalTitle: 'CPU utilization',
         renderFunc: (data, id, item) => scoreProgress(data, id, item),
         isChecked: true,
         isDisabled: false,
@@ -98,6 +101,7 @@ export const SYSTEM_TABLE_COLUMNS = [
     {
         key: 'performance_utilization.memory',
         title: 'Memory utilization',
+        modalTitle: 'Memory utilization',
         renderFunc: (data, id, item) => scoreProgress(data, id, item),
         isChecked: true,
         isDisabled: false,
@@ -110,6 +114,7 @@ export const SYSTEM_TABLE_COLUMNS = [
                 <span>I/O utilization</span>
             </Tooltip>
         ),
+        modalTitle: 'I/O utilization',
         dataLabel: 'I/O utilization',
         renderFunc: (data, id, item) => diskUsageData(data, id, item),
         isChecked: true,
@@ -119,6 +124,7 @@ export const SYSTEM_TABLE_COLUMNS = [
     {
         key: 'number_of_suggestions',
         title: 'Suggestions',
+        modalTitle: 'Suggestions',
         renderFunc: (data, id, item) => recommendations(data, id, item),
         isChecked: true,
         isDisabled: false,
@@ -127,6 +133,7 @@ export const SYSTEM_TABLE_COLUMNS = [
     {
         key: 'state',
         title: 'State',
+        modalTitle: 'State',
         renderFunc: (data) => displayState(data),
         isChecked: true,
         isDisabled: false,


### PR DESCRIPTION
**Fixed bug:**  the os columne name in modal as raised by QE team in jira card: https://issues.redhat.com/browse/RHIROS-518

### Screenshot

![image](https://user-images.githubusercontent.com/5928530/159674836-d4fd15b9-e01d-4019-887c-fc4fb7b7b1d9.png)
