### PR TITLE
Ref-RHIROS-579 code refactoring: DateFormat component from FEC

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "@redhat-cloud-services/frontend-components-utilities": "3.2.3",
         "babel-plugin-transform-imports": "^2.0.0",
         "classnames": "2.2.6",
-        "moment": "^2.29.2",
         "react": "16.13.1",
         "react-dom": "16.13.1",
         "react-redux": "7.2.0",
@@ -13753,6 +13752,7 @@
       "version": "2.29.2",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.2.tgz",
       "integrity": "sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==",
+      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -32449,7 +32449,8 @@
     "moment": {
       "version": "2.29.2",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.2.tgz",
-      "integrity": "sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg=="
+      "integrity": "sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==",
+      "dev": true
     },
     "moo": {
       "version": "0.5.1",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "@redhat-cloud-services/frontend-components-utilities": "3.2.3",
     "babel-plugin-transform-imports": "^2.0.0",
     "classnames": "2.2.6",
-    "moment": "^2.29.2",
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "react-redux": "7.2.0",

--- a/src/Components/Reports/Util.js
+++ b/src/Components/Reports/Util.js
@@ -1,12 +1,6 @@
 import { get } from 'lodash';
-import moment from 'moment';
 import { pdfRowKeys, percentageKeys, reportRowKeys, SYSTEMS_REPORT_FILE_NAME } from '../../constants';
-
-export const formatLastReported = (date) => {
-    const today = moment().format('YYYY-MM-DD');
-    const isTodayWithoutTime =  today === date;
-    return isTodayWithoutTime ? 'Today' : moment(date).fromNow();
-};
+import { dateStringByType } from '@redhat-cloud-services/frontend-components/DateFormat/helper';
 
 export const formatData = (data, type) => {
 
@@ -20,7 +14,7 @@ export const formatData = (data, type) => {
             let rowValue =  get(systemItem, rowKey, '');
             rowValue = (rowValue === null || rowValue === -1) ?  'N/A' : rowValue.toString();
             rowValue = (rowValue !== 'N/A' && percentageKeys.includes(rowKey)) ? `${rowValue}%` : rowValue;
-            rowValue = (rowKey === 'report_date') ? formatLastReported(rowValue) : rowValue;
+            rowValue = (rowKey === 'report_date') ? dateStringByType('relative')(new Date(rowValue)) : rowValue;
 
             if (type === 'json') {
                 rowData[rowKey] = rowValue;

--- a/src/Components/Reports/Util.test.js
+++ b/src/Components/Reports/Util.test.js
@@ -1,7 +1,7 @@
-import { generateFilterText, formatData, responseToCSVData, responseToJSONData, formatLastReported } from './Util';
+import { generateFilterText, formatData, responseToCSVData, responseToJSONData } from './Util';
 import { sysResponseTestData } from './UtilTestData';
 
-Date.now = jest.fn(() => new Date('2022-03-30T12:33:37.000Z'));
+Date.now = jest.fn(() => new Date('2022-03-30T00:33:37.000Z'));
 
 describe('Util generateFilterText method tests', () => {
     it('should generate filter text for name filter', () => {
@@ -69,7 +69,7 @@ describe('Util generateFilterText method tests', () => {
 describe('Util formatData method tests', () => {
     it('should generate array of data in the format required to generate PDF', () => {
         const expectedSystemsRowsData = [
-            ['ip-172-31-28-69.ec2.internal', 'RHEL 8.4', '90%', '97%', '0.314', '1', 'Undersized', '2 days ago'],
+            ['ip-172-31-28-69.ec2.internal', 'RHEL 8.4', '90%', '97%', '0.314', '1', 'Undersized', '1 day ago'],
             ['ros-system.internal', 'RHEL 8.4', '90%', '97%', '0.314', '1', 'Undersized', '32 minutes ago']
         ];
 
@@ -81,7 +81,7 @@ describe('Util formatData method tests', () => {
 
     it('should generate array of data (with 0%) in the format required to generate PDF', () => {
         const expectedSystemsRowsData = [
-            ['ip-172-31-28-69.ec2.internal', 'RHEL 8.4', '0%', '0%', '0.314', '1', 'Undersized', '2 days ago'],
+            ['ip-172-31-28-69.ec2.internal', 'RHEL 8.4', '0%', '0%', '0.314', '1', 'Undersized', '1 day ago'],
             ['ros-system.internal', 'RHEL 8.4', '90%', '97%', '0.314', '1', 'Undersized', '32 minutes ago']
         ];
 
@@ -96,7 +96,7 @@ describe('Util formatData method tests', () => {
 
     it('should generate array of data (handling null values) in the format required to generate PDF', () => {
         const expectedSystemsRowsData = [
-            ['ip-172-31-28-69.ec2.internal', 'RHEL 8.4', 'N/A', 'N/A', '0.314', 'N/A', 'Undersized', '2 days ago'],
+            ['ip-172-31-28-69.ec2.internal', 'RHEL 8.4', 'N/A', 'N/A', '0.314', 'N/A', 'Undersized', '1 day ago'],
             ['ros-system.internal', 'RHEL 8.4', '90%', '97%', '0.314', '1', 'Undersized', '32 minutes ago']
         ];
 
@@ -114,7 +114,7 @@ describe('Util formatData method tests', () => {
 describe('Util responseToCSVData test', () => {
     it('should format the data into CSV format', () => {
         // eslint-disable-next-line max-len
-        const expectedSystemsRowsData = `display_name,os,performance_utilization.cpu,performance_utilization.memory,performance_utilization.max_io,number_of_suggestions,state,cloud_provider,instance_type,idling_time,report_date\r\nip-172-31-28-69.ec2.internal,RHEL 8.4,90%,97%,0.314,1,Undersized,aws,t2.micro,19.70%,2 days ago\r\nros-system.internal,RHEL 8.4,90%,97%,0.314,1,Undersized,aws,t2.micro,19.70%,32 minutes ago`;
+        const expectedSystemsRowsData = `display_name,os,performance_utilization.cpu,performance_utilization.memory,performance_utilization.max_io,number_of_suggestions,state,cloud_provider,instance_type,idling_time,report_date\r\nip-172-31-28-69.ec2.internal,RHEL 8.4,90%,97%,0.314,1,Undersized,aws,t2.micro,19.70%,1 day ago\r\nros-system.internal,RHEL 8.4,90%,97%,0.314,1,Undersized,aws,t2.micro,19.70%,32 minutes ago`;
 
         sysResponseTestData[0].number_of_suggestions = 1;  /* eslint-disable-line camelcase */
         sysResponseTestData[0].performance_utilization.cpu = 90;
@@ -129,7 +129,7 @@ describe('Util responseToCSVData test', () => {
 describe('Util responseToJSONData test', () => {
     it('should format the data into JSON string format ', () => {
         // eslint-disable-next-line max-len
-        const expectedSystemsRowsData = '[{"display_name":"ip-172-31-28-69.ec2.internal","os":"RHEL 8.4","performance_utilization.cpu":"90%","performance_utilization.memory":"97%","performance_utilization.max_io":"0.314","number_of_suggestions":"1","state":"Undersized","cloud_provider":"aws","instance_type":"t2.micro","idling_time":"19.70%","report_date":"2 days ago"}]';
+        const expectedSystemsRowsData = '[{"display_name":"ip-172-31-28-69.ec2.internal","os":"RHEL 8.4","performance_utilization.cpu":"90%","performance_utilization.memory":"97%","performance_utilization.max_io":"0.314","number_of_suggestions":"1","state":"Undersized","cloud_provider":"aws","instance_type":"t2.micro","idling_time":"19.70%","report_date":"1 day ago"}]';
 
         sysResponseTestData[0].number_of_suggestions = 1;  /* eslint-disable-line camelcase */
         sysResponseTestData[0].performance_utilization.cpu = 90;
@@ -140,34 +140,6 @@ describe('Util responseToJSONData test', () => {
         const actualSystemsRowsData = responseToJSONData(sysResponseJSONData);
 
         expect(actualSystemsRowsData).toEqual(expectedSystemsRowsData);
-    });
-});
-
-describe('Util formatLastReported test', () => {
-    it('should format the date into last reported format - 6 days ago', () => {
-        const expectedLastReportedDate = '6 days ago';
-        const actualLastReportedDate = formatLastReported('2022-03-25 00:00:00+00:00');
-        expect(actualLastReportedDate).toEqual(expectedLastReportedDate);
-    });
-
-    it('should format the date into last reported format - 2 days ago', () => {
-        const expectedLastReportedDate = '2 days ago';
-        const actualLastReportedDate = formatLastReported('2022-03-29');
-        expect(actualLastReportedDate).toEqual(expectedLastReportedDate);
-
-    });
-
-    it('should format the date into last reported format - 11 minutes ago', () => {
-        const expectedLastReportedDate = '11 minutes ago';
-        const actualLastReportedDate = formatLastReported('2022-03-30 12:23:00+00:00');
-        expect(actualLastReportedDate).toEqual(expectedLastReportedDate);
-    });
-
-    it('should format the date into last reported format - for today without time', () => {
-        const expectedLastReportedDate = 'Today';
-        const actualLastReportedDate = formatLastReported('2022-03-30');
-        expect(actualLastReportedDate).toEqual(expectedLastReportedDate);
-
     });
 });
 

--- a/src/Components/Reports/UtilTestData.js
+++ b/src/Components/Reports/UtilTestData.js
@@ -31,6 +31,6 @@ export const sysResponseTestData = [
         instance_type: 't2.micro',  /* eslint-disable-line camelcase */
         idling_time: '19.70',  /* eslint-disable-line camelcase */
         os: 'RHEL 8.4',
-        report_date: '2022-03-30 12:02:00+00:00'  /* eslint-disable-line camelcase */
+        report_date: '2022-03-30 00:01:37+00:00'  /* eslint-disable-line camelcase */
     }
 ];

--- a/src/Components/RosTable/RenderColumn.js
+++ b/src/Components/RosTable/RenderColumn.js
@@ -1,7 +1,7 @@
 import { Tooltip } from '@patternfly/react-core';
 import React from 'react';
 import { NO_DATA_STATE, NO_DATA_VALUE } from '../../constants';
-import { formatLastReported } from '../Reports/Util';
+import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
 import './RenderColumn.scss';
 
 export const diskUsageData = (data, id, item) => {
@@ -52,6 +52,6 @@ export const displayLastReported = (data) => {
     return (
         data === null ?
             <span>{ NO_DATA_VALUE }</span> :
-            <span>{ formatLastReported(data) }</span>
+            <DateFormat date={ data } />
     );
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { nowrap } from '@patternfly/react-table';
 import { Tooltip } from '@patternfly/react-core';
 import { displayState, recommendations, scoreProgress, systemName } from './store/entitiesReducer';
 import { diskUsageData, displayLastReported, displayOS } from './Components/RosTable/RenderColumn';
@@ -145,7 +146,9 @@ export const SYSTEM_TABLE_COLUMNS = [
         renderFunc: (data) => displayLastReported(data),
         isChecked: true,
         isDisabled: false,
-        isShownByDefault: true
+        isShownByDefault: true,
+        transforms: [nowrap],
+        cellTransforms: [nowrap]
     }
 ];
 


### PR DESCRIPTION
### Description:

Refactored code to add `<DateFormat />` component from FEC library to be consistent with other services.
Jira: https://issues.redhat.com/browse/RHIROS-579

### References:

[Inventory Entities.js](https://github.com/RedHatInsights/insights-inventory-frontend/blob/aa81efb33c414ff6e5612befe41a028ac75948cd/src/store/entities.js#L56)

[Vulnerability report generation](https://github.com/RedHatInsights/vulnerability-ui/blob/3c42f8f392592eb3a299be5b1cbae9d7e9245798/src/Components/SmartComponents/Reports/Executive/FirstPage.js#L19)

[DateFormat Component from FEC](https://github.com/RedHatInsights/frontend-components/blob/4ccd3a53e7/packages/components/src/DateFormat/DateFormat.tsx)

[dateByStringType() from FEC library](https://github.com/RedHatInsights/frontend-components/blob/4ccd3a53e7/packages/components/src/DateFormat/helper.tsx#L39)

### Demo

https://drive.google.com/file/d/18w90dtodrr103BTXpG6ZG1rRd5ehJQoa/view?usp=sharing

![image](https://user-images.githubusercontent.com/5928530/163181722-b56eed75-0d87-4573-bc5e-f3b6ead8643a.png)
