### PR TITLE
RHIROS-905 fixed host API 400 error

### DIFF
--- a/src/Routes/RosPage/RosPage.js
+++ b/src/Routes/RosPage/RosPage.js
@@ -326,6 +326,8 @@ class RosPage extends React.Component {
                                 const invIds = (results.data || []).map(({ inventory_id: inventoryId }) => inventoryId);
                                 const invSystems = await this.fetchInventoryDetails(invIds, {
                                     ...config,
+                                    orderBy: undefined,
+                                    orderDirection: undefined,
                                     page: 1,
                                     hasItems: true
                                 });


### PR DESCRIPTION
### Description:

Due to the recent changes made in the `getEntities` api method on the insight-inventory-frontend [(PR for reference](https://github.com/RedHatInsights/insights-inventory-frontend/pull/1713/files)) the host api was also using the props value `orderBy` and `orderDirection` which was passed in the config object while making `getEntities` call (Check `fetchInventoryDetails` method) and hence report_date was passed in `orderBy` value which doesn't exist on the ineventory side it was giving error during the GET hosts API request. This PR fixes the issue by passing the undefined value for both `orderBy` and `orderDirection` config options while making inventory host API request.

**Note:** the inventory side of changes are only available in the stage-beta hence this issue was only coming in the stage-beta env.

**Jira card:**
 https://issues.redhat.com/browse/RHIROS-905

**References:**
https://github.com/RedHatInsights/insights-inventory-frontend/blob/master/doc/props_table.md#getentities

**Before:**
![image](https://user-images.githubusercontent.com/5928530/209642059-0d02d3ef-56d4-45ba-b61c-4ac8cd59324f.png)

![image](https://user-images.githubusercontent.com/5928530/209642171-baf2c770-2898-4986-8580-3caa53829f26.png)



**After:**

![image](https://user-images.githubusercontent.com/5928530/209641902-7e794b3f-c894-4139-b40f-9aecd338fd5f.png)
