### PR TITLE
updated node version to 16 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 notifications:
   email: false
 node_js:
-  - 14
+  - '16'
 install:
 - npm ci
 jobs:

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -9,7 +9,7 @@ export COMPONENT="ros"
 export IMAGE="quay.io/cloudservices/ros-frontend"
 export WORKSPACE=${WORKSPACE:-$APP_ROOT} # if running in jenkins, use the build's workspace
 export APP_ROOT=$(pwd)
-export NODE_BUILD_VERSION=14
+export NODE_BUILD_VERSION=16
 COMMON_BUILDER=https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master
 
 # --------------------------------------------

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -9,7 +9,7 @@ export COMPONENT="ros"
 export IMAGE="quay.io/cloudservices/ros-frontend"
 export WORKSPACE=${WORKSPACE:-$APP_ROOT} # if running in jenkins, use the build's workspace
 export APP_ROOT=$(pwd)
-export NODE_BUILD_VERSION=14
+export NODE_BUILD_VERSION=16
 COMMON_BUILDER=https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master
 
 # --------------------------------------------


### PR DESCRIPTION
### Description

updated node version from `14` to `16` (npm v8.19.3) in travis.yml file to fix the below CVE as it was fixed in the `npm 8.4.1`

**Jira:**
https://issues.redhat.com/browse/RHIROS-526

**Bugzilla:**
https://bugzilla.redhat.com/show_bug.cgi?id=2050282

**References**
* https://docs.npmjs.com/cli/v9/commands/npm-ci
* https://consoledot.pages.redhat.com/docs/dev/getting-started/frontend-migration.html#_step_3_add_build_and_pr_check_scripts

**Travis Screenshot:**

![image](https://user-images.githubusercontent.com/5928530/209812805-9556952a-43a9-40db-b195-ddc3ec349033.png)


