### PR TITLE
RHIROS-747 disable pagination when no systems

### DIFF
--- a/src/Routes/RosPage/ros-page.scss
+++ b/src/Routes/RosPage/ros-page.scss
@@ -29,10 +29,6 @@
   }
 }
 
-.pf-c-button.pf-m-plain {
-  color: black;
-}
-
 .progress-score-bar {
   grid-gap: var(--pf-global--spacer--xs);
 
@@ -51,13 +47,11 @@
   }
 }
 
-
 .blue-300{
   .pf-c-progress__indicator {
     background: var(--pf-global--palette--blue-300);
   }
 }
-
 
 .ros-page-header {
   width: auto;


### PR DESCRIPTION

- If we are on the first page/last page of the ROS landing page then `Go to previous page` and `Go to next page` buttons are disabled(grey) respectively. 
**First page**
![Screenshot from 2023-01-06 13-12-26](https://user-images.githubusercontent.com/61837065/210971020-f9554a2c-24ce-43b8-a81c-e6d119c603d8.png)
**Last page**
![Screenshot from 2023-01-06 13-11-54](https://user-images.githubusercontent.com/61837065/210970458-a0a5029e-82fa-4ee9-9036-dfa264b0f5e2.png)

- ROS landing page - when no systems are found
![ros_page](https://user-images.githubusercontent.com/61837065/210968161-4d613490-e85b-4520-90e1-7169657394a3.png)

- ROS details page
![ros_details_page](https://user-images.githubusercontent.com/61837065/210969362-c722a14d-3d72-4f62-9f0e-5957c4142007.png)

