### PR TITLE
RHIROS-909 fixed color codes for occurance table

### DIFF
--- a/src/Components/Reports/Common/ExecutiveFirstPage.js
+++ b/src/Components/Reports/Common/ExecutiveFirstPage.js
@@ -11,7 +11,7 @@ const renderOccurrenceBreakdown = (conditionsInfo) => {
     const ioOccurenceTableData = [
         [
             <View key={'disk-io-title'} style={styles.flexRow}>
-                <IconCanvas fillColor='#8BC1F7'/>
+                <IconCanvas fillColor='#0066CC'/>
                 <Text>Disk I/O</Text>
             </View>
 
@@ -21,7 +21,7 @@ const renderOccurrenceBreakdown = (conditionsInfo) => {
     const ramOccurrenceTableData = [
         [
             <View key={'memory-title'}  style={styles.flexRow}>
-                <IconCanvas fillColor='#002F5D'/>
+                <IconCanvas fillColor='#8BC1F7'/>
                 <Text>RAM</Text>
             </View>
 
@@ -31,7 +31,7 @@ const renderOccurrenceBreakdown = (conditionsInfo) => {
     const cpuOccurrenceTableData = [
         [
             <View key={'cpu-title'} style={styles.flexRow}>
-                <IconCanvas fillColor='#0066CC'/>
+                <IconCanvas fillColor='#002F5D'/>
                 <Text>CPU</Text>
             </View>
 


### PR DESCRIPTION
## Fixes/RHIROS-909 :boom:

## Why do we need this change? :thought_balloon:

the color codes in the breakdown of occurence section of executive report were different from the pie chart. This PR fixes the issue

Jira: https://issues.redhat.com/browse/RHIROS-909

## Documentation requires update? :memo:

- [ ] Yes
- [x] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [x] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added

## Additional :mega:

![image](https://user-images.githubusercontent.com/5928530/215498423-bdf41436-4f3a-4f0f-bc0f-8a179ca16f12.png)
