### PR TITLE
RHIROS-369 - Run Dependabot scans on Sunday

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -11,3 +11,6 @@ update_configs:
       - match:
           dependency_name: "@patternfly/*"
           dependency_type: "direct"
+    schedule:
+      interval: "weekly"
+      day: "sunday"


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

The dependabot creates 5 version updates pr by default this limits it to 3 and we run scans weekly on sunday so prs are ready to review on monday.

## Documentation requires update? :memo:

- [ ] Yes
- [x] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.