### PR TITLE
RHIROS-967 fixed grammatical content for PDF option under export

### DIFF
--- a/src/Routes/RosPage/RosPage.js
+++ b/src/Routes/RosPage/RosPage.js
@@ -435,7 +435,7 @@ class RosPage extends React.Component {
                                             variant='none'
                                             className="pf-c-dropdown__menu-item"
                                             onClick={() => this.setExportSystemsPDF(true)}>
-                                            Export as PDF
+                                            Export to PDF
                                         </Button>
                                     </li>
                                 ],


### PR DESCRIPTION
## PR Title :boom:

[RHIROS-967](https://issues.redhat.com/browse/RHIROS-967) fix grammatical content for PDF option under export dropdown


## Why do we need this change? :thought_balloon:

Consistency to be maintained for all options present under export dropdown

## Documentation requires update? :memo:

- [ ] Yes
- [x] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [x] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.