### PR TITLE
RHID-216 migrate to useChrome in ROS

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -50,7 +50,6 @@ class App extends Component {
         });
 
         const chrome = this.props.chrome;
-        chrome?.init();
         chrome?.identifyApp('ros');
         this.unregister = chrome.on('APP_NAVIGATION', (event) => {
             if (event.navId === 'ros') {

--- a/src/App.js
+++ b/src/App.js
@@ -8,6 +8,7 @@ import NotificationsPortal from '@redhat-cloud-services/frontend-components-noti
 import { notificationsReducer } from '@redhat-cloud-services/frontend-components-notifications/redux';
 import { systemRecsReducer, systemDetailReducer, isConfiguredReducer, systemColumnsReducer } from './store/reducers';
 import { register } from './store';
+import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 
 export const PermissionContext = createContext();
 
@@ -47,9 +48,11 @@ class App extends Component {
             isConfiguredReducer,
             systemColumnsReducer
         });
-        insights.chrome.init();
-        insights.chrome.identifyApp('ros');
-        this.unregister = insights.chrome.on('APP_NAVIGATION', (event) => {
+
+        const chrome = this.props.chrome;
+        chrome?.init();
+        chrome?.identifyApp('ros');
+        this.unregister = chrome?.on('APP_NAVIGATION', (event) => {
             if (event.navId === 'ros') {
                 this.props.history.push(`/${location.search}${location.hash}`);
             } else {
@@ -57,7 +60,7 @@ class App extends Component {
             }
         });
         (async () => {
-            const rosPermissions = await insights.chrome.getUserPermissions('ros', true);
+            const rosPermissions = await chrome?.getUserPermissions('ros', true);
             this.handlePermissionsUpdate(
                 rosPermissions.some(({ permission }) => this.hasPermission(permission, ['ros:*:*', 'ros:*:read']))
             );
@@ -92,12 +95,22 @@ class App extends Component {
 }
 
 App.propTypes = {
-    history: PropTypes.object
+    history: PropTypes.object,
+    chrome: PropTypes.object
 };
+
+const AppWithChrome = props => {
+    const chrome = useChrome();
+
+    return (
+        <App {...props} chrome={ chrome } />
+    );
+};
+
 
 /**
  * withRouter: https://reacttraining.com/react-router/web/api/withRouter
  * connect: https://github.com/reactjs/react-redux/blob/master/docs/api.md
  *          https://reactjs.org/docs/higher-order-components.html
  */
-export default withRouter (connect()(App));
+export default withRouter (connect()(AppWithChrome));

--- a/src/App.js
+++ b/src/App.js
@@ -52,7 +52,7 @@ class App extends Component {
         const chrome = this.props.chrome;
         chrome?.init();
         chrome?.identifyApp('ros');
-        this.unregister = chrome?.on('APP_NAVIGATION', (event) => {
+        this.unregister = chrome.on('APP_NAVIGATION', (event) => {
             if (event.navId === 'ros') {
                 this.props.history.push(`/${location.search}${location.hash}`);
             } else {
@@ -60,7 +60,7 @@ class App extends Component {
             }
         });
         (async () => {
-            const rosPermissions = await chrome?.getUserPermissions('ros', true);
+            const rosPermissions = await chrome.getUserPermissions('ros', true);
             this.handlePermissionsUpdate(
                 rosPermissions.some(({ permission }) => this.hasPermission(permission, ['ros:*:*', 'ros:*:read']))
             );
@@ -106,7 +106,6 @@ const AppWithChrome = props => {
         <App {...props} chrome={ chrome } />
     );
 };
-
 
 /**
  * withRouter: https://reacttraining.com/react-router/web/api/withRouter

--- a/src/Routes/RosPage/RosPage.js
+++ b/src/Routes/RosPage/RosPage.js
@@ -528,13 +528,12 @@ RosPage.propTypes = {
     chrome: PropTypes.object
 };
 
-
 const RosPageWithChrome =  props => {
     const chrome = useChrome();
 
     return (
         <RosPage {...props} chrome={ chrome } />
-    )
-}
+    );
+};
 
 export default withRouter(connect(mapStateToProps, mapDispatchToProps)(RosPageWithChrome));

--- a/src/Routes/RosPage/RosPage.js
+++ b/src/Routes/RosPage/RosPage.js
@@ -136,9 +136,6 @@ class RosPage extends React.Component {
     }
 
     async fetchSystems(fetchParams) {
-        const chrome = this.props.chrome;
-        await chrome?.auth.getUser();
-
         let params = {
             limit: fetchParams.perPage,
             offset: (fetchParams.page - 1) * fetchParams.perPage,

--- a/src/Routes/RosPage/RosPage.js
+++ b/src/Routes/RosPage/RosPage.js
@@ -27,6 +27,7 @@ import {
     clearNotifications
 } from '@redhat-cloud-services/frontend-components-notifications/redux';
 import { DownloadExecutivePDFReport } from '../../Components/Reports/ExecutivePDFReport';
+import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 
 /**
  * A smart component that handles all the api calls and data needed by the dumb components.
@@ -71,8 +72,9 @@ class RosPage extends React.Component {
 
     async componentDidMount() {
         document.title = 'Resource Optimization - Red Hat Insights';
-        insights.chrome?.hideGlobalFilter?.(true);
-        insights.chrome.appAction('ros-systems');
+        const chrome = this.props.chrome;
+        chrome?.hideGlobalFilter?.(true);
+        chrome?.appAction('ros-systems');
         await this.props.isROSConfigured();
         this.processQueryParams();
         this.processOsVersion();
@@ -134,7 +136,8 @@ class RosPage extends React.Component {
     }
 
     async fetchSystems(fetchParams) {
-        await window.insights.chrome.auth.getUser();
+        const chrome = this.props.chrome;
+        await chrome?.auth.getUser();
 
         let params = {
             limit: fetchParams.perPage,
@@ -521,7 +524,17 @@ RosPage.propTypes = {
     columns: PropTypes.array,
     changeSystemColumns: PropTypes.func,
     addNotification: PropTypes.func,
-    clearNotifications: PropTypes.func
+    clearNotifications: PropTypes.func,
+    chrome: PropTypes.object
 };
 
-export default withRouter(connect(mapStateToProps, mapDispatchToProps)(RosPage));
+
+const RosPageWithChrome =  props => {
+    const chrome = useChrome();
+
+    return (
+        <RosPage {...props} chrome={ chrome } />
+    )
+}
+
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(RosPageWithChrome));

--- a/src/Routes/RosSystemDetail/RosSystemDetail.js
+++ b/src/Routes/RosSystemDetail/RosSystemDetail.js
@@ -180,7 +180,7 @@ const RosSystemDetailWithChrome = props => {
     return (
         <RosSystemDetail { ...props } chrome={ chrome } />
     );
-}
+};
 
 export default withRouter(
     connect(

--- a/src/Routes/RosSystemDetail/RosSystemDetail.js
+++ b/src/Routes/RosSystemDetail/RosSystemDetail.js
@@ -28,6 +28,7 @@ import {
 } from '@patternfly/react-core';
 import { HistoricalDataChart } from '../../Components/HistoricalDataChart/HistoricalDataChart';
 import SystemDetailWrapper from '../../Components/SystemDetail/SystemDetail';
+import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 
 class RosSystemDetail extends React.Component {
     constructor(props) {
@@ -38,8 +39,9 @@ class RosSystemDetail extends React.Component {
     }
 
     async componentDidMount() {
-        insights.chrome?.hideGlobalFilter?.(true);
-        insights.chrome.appAction('system-detail');
+        const chrome = this.props.chrome;
+        chrome?.hideGlobalFilter?.(true);
+        chrome.appAction('system-detail');
         await this.props.loadSystemInfo(this.state.inventoryId);
         document.title = this.props.rosSystemInfo.display_name;
     }
@@ -153,7 +155,8 @@ RosSystemDetail.propTypes = {
     entity: PropTypes.object,
     loading: PropTypes.bool,
     rosSystemInfo: PropTypes.object,
-    loadSystemInfo: PropTypes.func
+    loadSystemInfo: PropTypes.func,
+    chrome: PropTypes.object
 };
 
 const mapStateToProps = (state, props) => {
@@ -171,8 +174,16 @@ function mapDispatchToProps(dispatch) {
     };
 }
 
+const RosSystemDetailWithChrome = props => {
+    const chrome = useChrome();
+
+    return (
+        <RosSystemDetail { ...props } chrome={ chrome } />
+    );
+}
+
 export default withRouter(
     connect(
         mapStateToProps,
-        mapDispatchToProps)(RosSystemDetail)
+        mapDispatchToProps)(RosSystemDetailWithChrome)
 );

--- a/src/Utilities/api.js
+++ b/src/Utilities/api.js
@@ -15,7 +15,7 @@ export const isROSConfigured = () => {
         window.location.origin
     );
     let response = fetch(url).then(handleErrors)
-        .then(res =>  res.json()).then(result => result);
+    .then(res =>  res.json()).then(result => result);
 
     return response;
 };
@@ -26,7 +26,7 @@ export const fetchSystemDetail = inventoryId => {
         window.location.origin
     );
     let response = fetch(url).then(handleErrors)
-        .then(res =>  res.json()).then(result => result);
+    .then(res =>  res.json()).then(result => result);
 
     return response;
 };
@@ -46,15 +46,15 @@ export const fetchSystemRecommendations = (inventoryId, options = {}) => {
     );
     url.search = new URLSearchParams(params).toString();
     let response = fetch(url).then((resp) => {
-            if (!resp.ok && resp.status === 404) {
-                return { hasError: true };
-            } else if (!resp.ok) {
-                throw Error(resp.statusText);
-            }
+        if (!resp.ok && resp.status === 404) {
+            return { hasError: true };
+        } else if (!resp.ok) {
+            throw Error(resp.statusText);
+        }
 
-            return resp.json();
-        })
-        .then(result => result);
+        return resp.json();
+    })
+    .then(result => result);
 
     return response;
 };
@@ -116,7 +116,7 @@ export const fetchSystemHistory = (inventoryId, limit) => {
     url.search = query.toString();
 
     let response = fetch(url).then(handleErrors)
-        .then(res =>  res.json()).then(result => result);
+    .then(res =>  res.json()).then(result => result);
 
     return response;
 };

--- a/src/Utilities/api.js
+++ b/src/Utilities/api.js
@@ -14,12 +14,8 @@ export const isROSConfigured = () => {
         ROS_API_ROOT + IS_CONFIGURED_API,
         window.location.origin
     );
-    let response = window.insights.chrome.auth
-    .getUser()
-    .then(() =>
-        fetch(url).then(handleErrors)
-        .then(res =>  res.json()).then(result => result)
-    );
+    let response = fetch(url).then(handleErrors)
+        .then(res =>  res.json()).then(result => result);
 
     return response;
 };
@@ -29,12 +25,8 @@ export const fetchSystemDetail = inventoryId => {
         ROS_API_ROOT + SYSTEMS_API_ROOT + `/${inventoryId}`,
         window.location.origin
     );
-    let response = window.insights.chrome.auth
-    .getUser()
-    .then(() =>
-        fetch(url).then(handleErrors)
-        .then(res =>  res.json()).then(result => result)
-    );
+    let response = fetch(url).then(handleErrors)
+        .then(res =>  res.json()).then(result => result);
 
     return response;
 };
@@ -53,10 +45,7 @@ export const fetchSystemRecommendations = (inventoryId, options = {}) => {
         window.location.origin
     );
     url.search = new URLSearchParams(params).toString();
-    let response = window.insights.chrome.auth
-    .getUser()
-    .then(() =>
-        fetch(url).then((resp) => {
+    let response = fetch(url).then((resp) => {
             if (!resp.ok && resp.status === 404) {
                 return { hasError: true };
             } else if (!resp.ok) {
@@ -65,15 +54,12 @@ export const fetchSystemRecommendations = (inventoryId, options = {}) => {
 
             return resp.json();
         })
-        .then(result => result)
-    );
+        .then(result => result);
 
     return response;
 };
 
 export const fetchSystems = async (fetchParams) => {
-    await window.insights.chrome.auth.getUser();
-
     const { perPage, orderBy, orderHow  } = fetchParams || {};
 
     const sortingHeader = {
@@ -129,19 +115,13 @@ export const fetchSystemHistory = (inventoryId, limit) => {
     let query = new URLSearchParams(params);
     url.search = query.toString();
 
-    let response = window.insights.chrome.auth
-    .getUser()
-    .then(() =>
-        fetch(url).then(handleErrors)
-        .then(res =>  res.json()).then(result => result)
-    );
+    let response = fetch(url).then(handleErrors)
+        .then(res =>  res.json()).then(result => result);
 
     return response;
 };
 
 export const fetchExecutiveReport = async () => {
-    await window.insights.chrome.auth.getUser();
-
     const url = new URL(CRC_PDF_GENERATE_API,  window.location.origin);
 
     return fetch(url, {


### PR DESCRIPTION
## Migrate to useChrome :boom:

Jira: https://issues.redhat.com/browse/RHIF-216

## Why do we need this change? :thought_balloon:

insights.chrome is deprecated, we need to start using useChrome hook from platform

## Documentation requires update? :memo:

- [ ] Yes
- [x] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Bugfix
- [ ] New Feature
- [x] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.