### PR TITLE
RHIROS-1051 Browser Titles Correction

### DIFF
--- a/src/Routes/RosPage/RosPage.js
+++ b/src/Routes/RosPage/RosPage.js
@@ -71,7 +71,7 @@ class RosPage extends React.Component {
     }
 
     async componentDidMount() {
-        document.title = 'Resource Optimization - Red Hat Insights';
+        document.title = 'Resource Optimization | Red Hat Insights';
         const chrome = this.props.chrome;
         chrome?.hideGlobalFilter?.(true);
         chrome?.appAction('ros-systems');


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

We have to follow the uniform format for all the services. Many services have sub services and browser titles use hyphen to distinguish the main service of the page. Now to include the "Red Hat Insights" in the title, we need a better separator. It is suggested to use pipeline ' | ' as the ultimate separator in the title. 

For example. Patch has advisories, packages and systems. Each of the sub-service will have name of the main service i.e. Patch after its name in the browser title.  Example of the same: Advisories - Patch | Red Hat Insights

Suggested format : ```Sub Service - Service | Red Hat Insights```

## Documentation requires update? :memo:

- [ ] Yes
- [x] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Bugfix
- [ ] New Feature
- [x] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.