### PR TITLE
RHIROS-1042 add 'no versions available' in OS version filter

### DIFF
--- a/src/Routes/RosPage/RosPage.js
+++ b/src/Routes/RosPage/RosPage.js
@@ -101,7 +101,7 @@ class RosPage extends React.Component {
     processOsVersion() {
         let osObject = {};
         osObject.label = 'Operating system';
-        osObject.type = 'checkbox';
+        osObject.type = conditionalFilterType.checkbox;
         osObject.filterValues = {};
         this.fetchSystems({
             perPage: -1
@@ -117,7 +117,7 @@ class RosPage extends React.Component {
             });
 
             if (osObject.filterValues.items.length === 0) {
-                osObject.filterValues.items = [{ value: '', label: 'No versions available' }];
+                osObject.filterValues.items = [{ label: 'No versions available' }];
                 osObject.type = conditionalFilterType.group;
             }
 

--- a/src/Routes/RosPage/RosPage.js
+++ b/src/Routes/RosPage/RosPage.js
@@ -28,6 +28,7 @@ import {
 } from '@redhat-cloud-services/frontend-components-notifications/redux';
 import { DownloadExecutivePDFReport } from '../../Components/Reports/ExecutivePDFReport';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
+import { conditionalFilterType } from '@redhat-cloud-services/frontend-components';
 
 /**
  * A smart component that handles all the api calls and data needed by the dumb components.
@@ -114,6 +115,11 @@ class RosPage extends React.Component {
             }, []))).map(os => {
                 return { label: os, value: os.split(' ')[1] };
             });
+
+            if (osObject.filterValues.items.length === 0) {
+                osObject.filterValues.items = [{ value: '', label: 'No versions available' }];
+                osObject.type = conditionalFilterType.group;
+            }
 
             this.setState({
                 OSFObject: osObject


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

Show `No versions available` for OS filtering when no system.

## Documentation requires update? :memo:

- [ ] Yes
- [X] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [X] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.