### PR TITLE
RHIROS-1171 no permission view for suggested instance types page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -50,7 +50,7 @@ class App extends Component {
         });
 
         const chrome = this.props.chrome;
-        chrome?.identifyApp('ros');
+        chrome?.updateDocumentTitle('Resource Optimization | Red Hat Insights');
         this.unregister = chrome.on('APP_NAVIGATION', (event) => {
             if (event.navId === 'ros') {
                 this.props.history.push(`/${location.search}${location.hash}`);
@@ -79,14 +79,9 @@ class App extends Component {
             arePermissionsLoaded } = this.state;
         return (
             arePermissionsLoaded
-                ? <PermissionContext.Provider
-                    value={ {
-                        permissions: {
-                            systemsRead: hasReadPermissions
-                        }
-                    } }>
+                ? <PermissionContext.Provider value={ hasReadPermissions }>
                     <NotificationsPortal />
-                    <Routes childProps={ this.props } />
+                    <Routes />
                 </PermissionContext.Provider>
                 : null
         );

--- a/src/App.js
+++ b/src/App.js
@@ -79,7 +79,12 @@ class App extends Component {
             arePermissionsLoaded } = this.state;
         return (
             arePermissionsLoaded
-                ? <PermissionContext.Provider value={ hasReadPermissions }>
+                ? <PermissionContext.Provider
+                    value={{
+                        permissions: {
+                            hasRead: hasReadPermissions
+                        }
+                    }}>
                     <NotificationsPortal />
                     <Routes />
                 </PermissionContext.Provider>

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -5,6 +5,7 @@ import { Bullseye, Spinner } from '@patternfly/react-core';
 
 const RosPage = lazy(() => import(/* webpackChunkName: "RosPage" */ './Routes/RosPage/RosPage'));
 const RosSystemDetail = lazy(() => import(/* webpackChunkName: "RosSystemDetail" */ './Routes/RosSystemDetail/RosSystemDetail'));
+const RosSuggestedInstance = lazy(() => import(/* webpackChunkName: "RosSuggestedInstance" */ './Routes/RosSuggestedInstance/RosSuggestedInstance'));
 
 export const Routes = () => (
     <Suspense fallback={<Bullseye>
@@ -12,6 +13,7 @@ export const Routes = () => (
     </Bullseye>}>
         <Switch>
             <Route exact path='/' component={RosPage} />
+            <Route path='/suggested-instance-types' component={RosSuggestedInstance}/>
             <Route path='/:inventoryId' component={RosSystemDetail} />
             <Redirect path="*" to='/' />
         </Switch>

--- a/src/Routes/RosPage/RosPage.js
+++ b/src/Routes/RosPage/RosPage.js
@@ -14,7 +14,9 @@ import { changeSystemColumns, loadIsConfiguredInfo } from '../../store/actions';
 import {
     CUSTOM_FILTERS, ROS_API_ROOT,
     SYSTEMS_API_ROOT, SYSTEM_TABLE_COLUMNS,
-    WITH_SUGGESTIONS_PARAM, WITH_WAITING_FOR_DATA_PARAM } from '../../constants';
+    WITH_SUGGESTIONS_PARAM, WITH_WAITING_FOR_DATA_PARAM,
+    SERVICE_NAME
+} from '../../constants';
 import { ServiceNotConfigured } from '../../Components/ServiceNotConfigured/ServiceNotConfigured';
 import { PermissionContext } from '../../App';
 
@@ -464,9 +466,9 @@ class RosPage extends React.Component {
         return (
             <React.Fragment>
                 <PermissionContext.Consumer>
-                    { hasPermissions =>
-                        hasPermissions === false
-                            ? <NotAuthorized serviceName='Resource Optimization' />
+                    { value =>
+                        value.permissions.hasRead === false
+                            ? <NotAuthorized serviceName={SERVICE_NAME} />
                             : this.renderConfigStepsOrTable()
                     }
                 </PermissionContext.Consumer>

--- a/src/Routes/RosPage/RosPage.js
+++ b/src/Routes/RosPage/RosPage.js
@@ -70,7 +70,6 @@ class RosPage extends React.Component {
     }
 
     async componentDidMount() {
-        document.title = 'Resource Optimization | Red Hat Insights';
         const chrome = this.props.chrome;
         chrome?.hideGlobalFilter?.(true);
         chrome?.appAction('ros-systems');
@@ -465,8 +464,8 @@ class RosPage extends React.Component {
         return (
             <React.Fragment>
                 <PermissionContext.Consumer>
-                    { value =>
-                        value.permissions.systemsRead === false
+                    { hasPermissions =>
+                        hasPermissions === false
                             ? <NotAuthorized serviceName='Resource Optimization' />
                             : this.renderConfigStepsOrTable()
                     }

--- a/src/Routes/RosSuggestedInstance/RosSuggestedInstance.js
+++ b/src/Routes/RosSuggestedInstance/RosSuggestedInstance.js
@@ -8,9 +8,10 @@ import {
     EmptyStateVariant,
     Title
 } from '@patternfly/react-core';
+import { SERVICE_NAME } from '../../constants';
 
 export default function RosSuggestedInstance() {
-    const hasPermissions = useContext(PermissionContext);
+    const hasPermissions = useContext(PermissionContext).permissions.hasRead;
     const { hideGlobalFilter, updateDocumentTitle } = useChrome();
 
     useEffect(() => {
@@ -21,7 +22,7 @@ export default function RosSuggestedInstance() {
     return (
         hasPermissions
             ? <NoEntities />
-            : <NotAuthorized serviceName='Resource Optimization'/>
+            : <NotAuthorized serviceName={SERVICE_NAME} />
     );
 }
 

--- a/src/Routes/RosSuggestedInstance/RosSuggestedInstance.js
+++ b/src/Routes/RosSuggestedInstance/RosSuggestedInstance.js
@@ -1,0 +1,38 @@
+import React, { useContext, useEffect } from 'react';
+import { PermissionContext } from '../../App';
+import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
+import { NotAuthorized } from '@redhat-cloud-services/frontend-components/NotAuthorized';
+import {
+    EmptyStateBody,
+    EmptyState,
+    EmptyStateVariant,
+    Title
+} from '@patternfly/react-core';
+
+export default function RosSuggestedInstance() {
+    const hasPermissions = useContext(PermissionContext);
+    const { hideGlobalFilter, updateDocumentTitle } = useChrome();
+
+    useEffect(() => {
+        updateDocumentTitle('Suggested Instance Types - Resource Optimization | Red Hat Insights');
+        hideGlobalFilter();
+    }, []);
+
+    return (
+        hasPermissions
+            ? <NoEntities />
+            : <NotAuthorized serviceName='Resource Optimization'/>
+    );
+}
+
+// TODO: remove or update this component when working on RHIROS-1166
+const NoEntities = () => (
+    <EmptyState variant={EmptyStateVariant.full}>
+        <Title headingLevel="h5" size="lg">
+          Suggested Instance Types Table
+        </Title>
+        <EmptyStateBody>
+            No records found
+        </EmptyStateBody>
+    </EmptyState>
+);

--- a/src/Routes/RosSystemDetail/RosSystemDetail.js
+++ b/src/Routes/RosSystemDetail/RosSystemDetail.js
@@ -29,6 +29,7 @@ import {
 import { HistoricalDataChart } from '../../Components/HistoricalDataChart/HistoricalDataChart';
 import SystemDetailWrapper from '../../Components/SystemDetail/SystemDetail';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
+import { SERVICE_NAME } from '../../constants';
 
 class RosSystemDetail extends React.Component {
     constructor(props) {
@@ -106,9 +107,9 @@ class RosSystemDetail extends React.Component {
         return (
             <React.Fragment>
                 <PermissionContext.Consumer>
-                    { hasPermissions =>
-                        hasPermissions === false
-                            ? <NotAuthorized serviceName='Resource Optimization'/>
+                    { value =>
+                        value.permissions.hasRead === false
+                            ? <NotAuthorized serviceName={SERVICE_NAME} />
                             : <DetailWrapper
                                 inventoryId={this.state.inventoryId}
                                 onLoad={({ mergeWithDetail, INVENTORY_ACTION_TYPES }) => {

--- a/src/Routes/RosSystemDetail/RosSystemDetail.js
+++ b/src/Routes/RosSystemDetail/RosSystemDetail.js
@@ -46,9 +46,10 @@ class RosSystemDetail extends React.Component {
     }
 
     componentDidUpdate() {
+        const chrome = this.props.chrome;
         const displayName = this.props.rosSystemInfo.display_name;
         if (displayName && displayName !== document.title) {
-            document.title = displayName;
+            chrome?.updateDocumentTitle(displayName);
         }
     }
 
@@ -105,8 +106,8 @@ class RosSystemDetail extends React.Component {
         return (
             <React.Fragment>
                 <PermissionContext.Consumer>
-                    { value =>
-                        value.permissions.systemsRead === false
+                    { hasPermissions =>
+                        hasPermissions === false
                             ? <NotAuthorized serviceName='Resource Optimization'/>
                             : <DetailWrapper
                                 inventoryId={this.state.inventoryId}

--- a/src/constants.js
+++ b/src/constants.js
@@ -33,6 +33,9 @@ export const NO_DATA_VALUE = 'N/A';
 // eslint-disable-next-line max-len
 export const ENABLE_PSI_URL = 'https://access.redhat.com/documentation/en-us/red_hat_insights/2023/html-single/assessing_and_monitoring_rhel_resource_optimization_with_insights_for_red_hat_enterprise_linux/index#proc-ros-psi-enable__assembly-ros-install';
 
+// Service name
+export const SERVICE_NAME = 'Resource Optimization';
+
 // Custom Filters
 export const CUSTOM_FILTERS = {
     state: {


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

[RHIROS-1171](https://issues.redhat.com/browse/RHIROS-1171)

## Documentation requires update? :memo:

- [ ] Yes
- [X] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Bugfix
- [X] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added

## Additional :mega:

- Add `NotAuthorized` view.
- remove [deprecated](http://front-end-docs-insights.apps.ocp4.prod.psi.redhat.com/chrome/chrome-api#identifyApp) `identifyApp`.
- set document title for suggested instance type page as `Suggested Instance Types - Resource Optimization | Red Hat Insights`
- hide global tag filter.