### PR TITLE
cherry-pick-into-prod-beta

### DIFF
--- a/src/Routes/RosSystemDetail/RosSystemDetail.js
+++ b/src/Routes/RosSystemDetail/RosSystemDetail.js
@@ -38,12 +38,18 @@ class RosSystemDetail extends React.Component {
         };
     }
 
-    async componentDidMount() {
+    componentDidMount() {
         const chrome = this.props.chrome;
         chrome?.hideGlobalFilter?.(true);
         chrome.appAction('system-detail');
-        await this.props.loadSystemInfo(this.state.inventoryId);
-        document.title = this.props.rosSystemInfo.display_name;
+        this.props.loadSystemInfo(this.state.inventoryId);
+    }
+
+    componentDidUpdate() {
+        const displayName = this.props.rosSystemInfo.display_name;
+        if (displayName && displayName !== document.title) {
+            document.title = displayName;
+        }
     }
 
     renderChildrenNode() {


### PR DESCRIPTION


## cherry-pick-into-prod-beta :boom:
 
This PR will push the fix to below bug into prod-beta
RHCLOUD-26437 - Remove async lifecycle hook for ROS Details route.

(cherry picked from commit e0fc43293bf0ac05fc528f5841536cd6dd25ec65)

## Why do we need this change? :thought_balloon:

For ROS frontend release

## Documentation requires update? :memo:

- [ ] Yes
- [ ] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.