### PR TITLE
Ref-RHIROS-1215 remove link from group column

### DIFF
--- a/src/Components/RosTable/RenderColumn.js
+++ b/src/Components/RosTable/RenderColumn.js
@@ -85,8 +85,6 @@ export const displayGroup = (data) => {
     return (
         data.length === 0 ?
             <span>{ NO_DATA_VALUE }</span> :
-            <a href={`./insights/inventory/groups/${data[0].id}`}>
-                <span>{ data[0].name }</span>
-            </a>
+            <span>{ data[0].name }</span>
     );
 };


### PR DESCRIPTION
## Remove link from group column :boom:

Jira: https://issues.redhat.com/browse/ESSNTL-3723

## Why do we need this change? :thought_balloon:

Based on recent discussion with inventory team it was decided that we will keep group links only on the inventory side and rest of the services will remove the groups links from the column. 
Hence I created PR to address the same.
Slack conversation link: https://redhat-internal.slack.com/archives/C05KZQ2Q6FJ/p1691478044968029

## Documentation requires update? :memo:

- [ ] Yes
- [ ] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.