### PR TITLE
fix inventory header margin

### DIFF
--- a/src/Routes/RosSystemDetail/ros-details-page.scss
+++ b/src/Routes/RosSystemDetail/ros-details-page.scss
@@ -31,10 +31,5 @@
         display: none !important;
       }
     }
-    .ins-c-inventory__detail--header .pf-v5-l-split__item:last-child {
-      div {
-        margin-right:0px;
-      }
-    }
   }
 }


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

The margin between the delete button and Actions dropdown is 0px because of scss file. This PR restores the proper margin.

## Documentation requires update? :memo:

- [ ] Yes
- [x] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [x] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.