### PR TITLE
fix(executive-report): use correct ros backend identificator

### DIFF
--- a/src/PDFTemplates/ExecutiveReport/ExecutiveReport.tsx
+++ b/src/PDFTemplates/ExecutiveReport/ExecutiveReport.tsx
@@ -142,7 +142,7 @@ const DescriptionList = ({
 type CreateAxiosRequest<T = any> = (service: string, config: AxiosRequestConfig) => Promise<T>;
 
 export const fetchData: FetchData = async (createAsyncRequest: CreateAxiosRequest) => {
-    return createAsyncRequest('ros', {
+    return createAsyncRequest('ros-backend', {
         method: 'GET',
         url: '/api/ros/v1/executive_report'
     });


### PR DESCRIPTION
## PR Title :boom:

fix(executive-report): use correct ros backend identificator

Suggested formats: 

1. Refs [#RHIROS-XXX - Title](https://issues.redhat.com/browse/RHCLOUD-40736)


## Why do we need this change? :thought_balloon:

When deployed, the host of the service is identified by the service name described in clowder resource. Ros backend is named `ros-backend` not `ros`.

## Documentation requires update? :memo:

- [ ] Yes
- [x] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [x] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
