### PR TITLE
chore: RHINENG-18906 - upgraded to node v22

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -9,7 +9,7 @@ export COMPONENT="ros"
 export IMAGE="quay.io/cloudservices/ros-frontend"
 export WORKSPACE=${WORKSPACE:-$APP_ROOT} # if running in jenkins, use the build's workspace
 export APP_ROOT=$(pwd)
-export NODE_BUILD_VERSION=16
+export NODE_BUILD_VERSION=22
 COMMON_BUILDER=https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master
 
 # --------------------------------------------

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "1.1.0",
   "private": false,
   "engines": {
-    "node": ">=16.0.0",
-    "npm": ">=7.0.0"
+    "node": ">=22.0.0",
+    "npm": ">=10.0.0"
   },
   "scripts": {
     "build": "npm run build:prod",

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -9,7 +9,7 @@ export COMPONENT="ros"
 export IMAGE="quay.io/cloudservices/ros-frontend"
 export WORKSPACE=${WORKSPACE:-$APP_ROOT} # if running in jenkins, use the build's workspace
 export APP_ROOT=$(pwd)
-export NODE_BUILD_VERSION=16
+export NODE_BUILD_VERSION=22
 COMMON_BUILDER=https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master
 
 # --------------------------------------------


### PR DESCRIPTION
## upgraded to node v22 :boom:

upgraded to node v22
**Jira:** [RHINENG-18906](https://issues.redhat.com/browse/RHINENG-18906)

## Why do we need this change? :thought_balloon:

Please include the __context of this change__ here.

## Documentation requires update? :memo:

- [ ] Yes
- [ ] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.

## Summary by Sourcery

Upgrade project to use Node.js v22 by updating engine requirements and adjusting build scripts

Enhancements:
- Bump Node.js engine requirement to >=22 and npm to >=10 in package.json

Build:
- Update NODE_BUILD_VERSION to 22 in build_deploy.sh and pr_check.sh