### PR TITLE
chore: configure renovate to only run on main branch

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
     "schedule": [
       "on Monday after 3am and before 10am"
     ],
+    "baseBranches": ["main"],
     "ignorePaths": [
       ".pre-commit-config.yaml"
     ]


### PR DESCRIPTION
Currently, mintmaker will try to update all onboarded components but this is unnecessary for SC branches and just clutters the repo PR list. Only allowing renovate to run on main/master should help.