### PR TITLE
RHINENG-19632 disable system report export pdf functionality

### DIFF
--- a/src/Routes/RosPage/RosPage.js
+++ b/src/Routes/RosPage/RosPage.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { PageHeader, PageHeaderTitle } from '@redhat-cloud-services/frontend-components/PageHeader';
 import { Main } from '@redhat-cloud-services/frontend-components/Main';
-import { Button, Card, CardBody, Flex } from '@patternfly/react-core';
+import { Card, CardBody, Flex } from '@patternfly/react-core';
 import { SortByDirection } from '@patternfly/react-table';
 import { connect } from 'react-redux';
 import { InventoryTable } from '@redhat-cloud-services/frontend-components/Inventory';
@@ -486,17 +486,6 @@ class RosPage extends React.Component {
                                     }}
                                     exportConfig={{
                                         isDisabled: disableExport,
-                                        extraItems: [
-                                            <li key='pdf-button-item' role='menuitem'>
-                                                <Button
-                                                    key='pdf-download-button'
-                                                    variant='none'
-                                                    className="pf-v5-c-dropdown pf-v5-c-dropdown__menu-item"
-                                                    onClick={() => this.setExportSystemsPDF(true)}>
-                                                Export to PDF
-                                                </Button>
-                                            </li>
-                                        ],
                                         ouiaId: 'export',
                                         onSelect: (_event, fileType) => this.onExportOptionSelect(fileType)
                                     }}


### PR DESCRIPTION
## disable system report export pdf functionality :boom:

disable system report export pdf functionality
**Jira:** :- [RHINENG-19632](https://issues.redhat.com/browse/RHINENG-19632)

## Why do we need this change? :thought_balloon:

Please include the __context of this change__ here.

## Documentation requires update? :memo:

- [ ] Yes
- [x] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added

## Additional :mega:

<img width="1896" height="1081" alt="image" src="https://github.com/user-attachments/assets/f539a0c6-6a0a-4af4-8561-f8a6f01af139" />

## Summary by Sourcery

Enhancements:
- Remove the ‘Export to PDF’ button and related menu entry from the system report export dropdown