### PR TITLE
chore: add analytics API keys and supportCaseData to deploy config

### DIFF
--- a/deploy/frontend.yaml
+++ b/deploy/frontend.yaml
@@ -63,7 +63,14 @@ objects:
                   href: /insights/ros
                   product: Red Hat Insights
       module:
+        analytics:
+          APIKey: apRCg9V6oMXCcnTingqRYW6m1er4hkCW
+          APIKeyDev: aMINBssUhXV1okzk7ZBaqwdTgtA0ySpg
         manifestLocation: "/apps/ros/fed-mods.json"
+        config:
+          supportCaseData:
+            product: Red Hat Insights
+            version: Resource Optimization
         modules:
           - id: ros
             module: "./RootApp"


### PR DESCRIPTION
## Summary
- Adds the `analytics` block with `APIKey` and `APIKeyDev` to the `module` section in `deploy/frontend.yaml`
- Adds `config.supportCaseData` with product and version fields
- Aligns with the pattern used by other frontends (inventory, advisor, tasks, ocp-advisor)

## Test plan
- [ ] Verify the YAML is valid and the deploy CRD parses correctly
- [ ] Confirm analytics events are sent in stage with the correct API key

## Summary by Sourcery

Add analytics configuration and support case metadata to the frontend deploy configuration.

New Features:
- Introduce analytics API key configuration for the ROS frontend module.
- Add support case metadata configuration (product and version) for the ROS frontend module.