### PR TITLE
fix(RHINENG-26137): deal with permissions correctly based on FF

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,10 +4,12 @@ import './App.scss';
 import NotificationsProvider from '@redhat-cloud-services/frontend-components-notifications/NotificationsProvider';
 import { systemRecsReducer, systemDetailReducer, isConfiguredReducer, systemColumnsReducer, suggestedInstanceTypesReducer } from './store/reducers';
 import { register } from './store';
+import { Bullseye, Spinner } from '@patternfly/react-core';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 import { useKesselPermissions } from './Utilities/hooks/useKesselPermissions';
 import { useV1Permissions } from './Utilities/hooks/useV1Permissions';
 import useFeatureFlag from './Utilities/useFeatureFlag';
+import { useFlagsStatus } from '@unleash/proxy-client-react';
 
 export const PermissionContext = createContext();
 
@@ -20,9 +22,10 @@ const REQUIRED_PERMISSIONS = ['ros:analysis:read'];
 const App = () => {
     const chrome = useChrome();
     const isKesselEnabled = useFeatureFlag('ros-frontend.kessel-enabled');
+    const { flagsReady } = useFlagsStatus();
 
-    const kesselPermissions = useKesselPermissions(REQUIRED_PERMISSIONS, isKesselEnabled);
-    const v1Permissions = useV1Permissions(chrome, !isKesselEnabled);
+    const kesselPermissions = useKesselPermissions(REQUIRED_PERMISSIONS, isKesselEnabled && flagsReady);
+    const v1Permissions = useV1Permissions(chrome, !isKesselEnabled && flagsReady);
 
     const { hasAccess, isLoading } = isKesselEnabled ? kesselPermissions : v1Permissions;
 
@@ -37,8 +40,8 @@ const App = () => {
         chrome?.updateDocumentTitle('Resource Optimization - Business');
     }, [chrome]);
 
-    if (isLoading) {
-        return null;
+    if (isLoading || !flagsReady) {
+        return <Bullseye><Spinner size="xl" /></Bullseye>;
     }
 
     return (

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,0 +1,145 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+jest.mock('./Routes', () => ({
+    ROSRoutes: () => <div data-testid="ros-routes">ROSRoutes</div>
+}));
+
+jest.mock(
+    '@redhat-cloud-services/frontend-components-notifications/NotificationsProvider',
+    () => ({
+        __esModule: true,
+        default: ({ children }) => <>{children}</>
+    })
+);
+
+jest.mock('./store', () => ({
+    register: jest.fn()
+}));
+
+jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
+    useChrome: jest.fn()
+}));
+
+jest.mock('./Utilities/useFeatureFlag', () => jest.fn());
+
+jest.mock('@unleash/proxy-client-react', () => ({
+    ...jest.requireActual('@unleash/proxy-client-react'),
+    useFlagsStatus: jest.fn(() => ({ flagsReady: true }))
+}));
+
+jest.mock('./Utilities/hooks/useKesselPermissions');
+jest.mock('./Utilities/hooks/useV1Permissions');
+
+import App from './App';
+import { register } from './store';
+import useFeatureFlag from './Utilities/useFeatureFlag';
+import { useFlagsStatus } from '@unleash/proxy-client-react';
+import { useKesselPermissions } from './Utilities/hooks/useKesselPermissions';
+import { useV1Permissions } from './Utilities/hooks/useV1Permissions';
+import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
+
+describe('App', () => {
+    const mockUpdateDocumentTitle = jest.fn();
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        useChrome.mockReturnValue({
+            updateDocumentTitle: mockUpdateDocumentTitle,
+            getUserPermissions: jest.fn().mockResolvedValue([])
+        });
+        useFlagsStatus.mockReturnValue({ flagsReady: true });
+        useFeatureFlag.mockReturnValue(false);
+        useKesselPermissions.mockReturnValue({
+            hasAccess: false,
+            isLoading: false
+        });
+        useV1Permissions.mockReturnValue({
+            hasAccess: true,
+            isLoading: false
+        });
+    });
+
+    it('shows a centered spinner while feature flags are not ready', () => {
+        useFlagsStatus.mockReturnValue({ flagsReady: false });
+
+        const { container } = render(<App />);
+
+        expect(
+            container.querySelector('.pf-v6-c-spinner')
+        ).toBeInTheDocument();
+        expect(screen.queryByTestId('ros-routes')).not.toBeInTheDocument();
+    });
+
+    it('shows a spinner while V1 permissions are loading', () => {
+        useFeatureFlag.mockReturnValue(false);
+        useV1Permissions.mockReturnValue({
+            hasAccess: false,
+            isLoading: true
+        });
+
+        const { container } = render(<App />);
+
+        expect(
+            container.querySelector('.pf-v6-c-spinner')
+        ).toBeInTheDocument();
+        expect(screen.queryByTestId('ros-routes')).not.toBeInTheDocument();
+    });
+
+    it('shows a spinner while Kessel permissions are loading', () => {
+        useFeatureFlag.mockReturnValue(true);
+        useKesselPermissions.mockReturnValue({
+            hasAccess: false,
+            isLoading: true
+        });
+
+        const { container } = render(<App />);
+
+        expect(
+            container.querySelector('.pf-v6-c-spinner')
+        ).toBeInTheDocument();
+        expect(screen.queryByTestId('ros-routes')).not.toBeInTheDocument();
+    });
+
+    it('renders routes when flags are ready and V1 permissions have finished loading', () => {
+        useFeatureFlag.mockReturnValue(false);
+        useV1Permissions.mockReturnValue({
+            hasAccess: true,
+            isLoading: false
+        });
+
+        render(<App />);
+
+        expect(screen.getByTestId('ros-routes')).toBeInTheDocument();
+    });
+
+    it('renders routes when flags are ready and Kessel permissions have finished loading', () => {
+        useFeatureFlag.mockReturnValue(true);
+        useKesselPermissions.mockReturnValue({
+            hasAccess: true,
+            isLoading: false
+        });
+
+        render(<App />);
+
+        expect(screen.getByTestId('ros-routes')).toBeInTheDocument();
+    });
+
+    it('registers store reducers and sets the document title on mount', () => {
+        render(<App />);
+
+        expect(register).toHaveBeenCalledTimes(1);
+        expect(register).toHaveBeenCalledWith({
+            systemDetailReducer: expect.anything(),
+            systemRecsReducer: expect.anything(),
+            isConfiguredReducer: expect.anything(),
+            systemColumnsReducer: expect.anything(),
+            suggestedInstanceTypesReducer: expect.anything()
+        });
+        expect(mockUpdateDocumentTitle).toHaveBeenCalledWith(
+            'Resource Optimization - Business'
+        );
+    });
+});

--- a/src/Utilities/hooks/useV1Permissions.js
+++ b/src/Utilities/hooks/useV1Permissions.js
@@ -13,6 +13,8 @@ export const useV1Permissions = (chrome, enabled) => {
             return;
         }
 
+        setIsLoading(true);
+
         (async () => {
             const rosPermissions = await chrome.getUserPermissions('ros', true);
             const hasRead = rosPermissions.some(({ permission }) =>


### PR DESCRIPTION
wait when feature flag is loaded and then fetch permissions. This will help to avoid cases when FF is not loaded yet so we don't call RBACv1 or Kessel until we have value ready

## Summary by Sourcery

Bug Fixes:
- Prevent permission checks from running before feature flag values are loaded by conditioning RBAC calls on flag readiness.